### PR TITLE
Use `np.prod` instead of `np.product`

### DIFF
--- a/codonbias/scores.py
+++ b/codonbias/scores.py
@@ -502,7 +502,7 @@ class EffectiveNumberOfCodons(ScalarScore, WeightScore):
     def _calc_BCC(self, BNC):
         """ Compute the background CODON composition of the sequence. """
         BCC = self.template.copy()
-        BCC['bcc'] = [np.product([BNC[c] for c in cod])
+        BCC['bcc'] = [np.prod([BNC[c] for c in cod])
                       for cod in BCC.index.get_level_values('codon')]
         BCC = BCC['bcc']
         BCC /= BCC.groupby('aa').sum()


### PR DESCRIPTION
[`np.product` has been deprecated is NumPy 1.25](https://numpy.org/doc/2.1/release/1.25.0-notes.html), and [permanently removed in NumPy 2.x](https://github.com/numpy/numpy/pull/23314).

This MR corrects this deprecated use. I would also suggest releasing a version (`0.3.3`?) to allow projects based on this project to update NumPy 🙂.