### PR TITLE
refactor: WeightOptimizer(strategy=...) replaces Max/Min/BalancedWeight

### DIFF
--- a/codonbias/optimizers.py
+++ b/codonbias/optimizers.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 
@@ -6,11 +8,17 @@ from codonbias import scores, stats
 
 class WeightOptimizer(object):
     """
-    Abstract class for optimizers that use codon weights to choose
-    between synonymous sequences.
+    Optimizer that uses codon weights to choose between synonymous codons.
 
     Parameters
     ----------
+    strategy : {'max', 'min', 'balanced'}
+        Selection strategy:
+        - 'max': pick the highest-weight codon per position.
+        - 'min': pick the lowest-weight codon per position.
+        - 'balanced': sample codons with probability proportional to their
+          weight, yielding a balanced distribution where more optimal
+          codons appear at higher frequencies.
     weights : pd.Series, optional
         Codon weights, according to which optimization will encode the
         sequence, by default None
@@ -23,8 +31,23 @@ class WeightOptimizer(object):
         NCBI genetic code ID, by default 1
     """
 
-    def __init__(self, weights=None, model=None, higher_is_better=True, genetic_code=1):
+    _STRATEGIES = ("max", "min", "balanced")
+
+    def __init__(
+        self,
+        strategy,
+        weights=None,
+        model=None,
+        higher_is_better=True,
+        genetic_code=1,
+    ):
+        if strategy not in self._STRATEGIES:
+            raise ValueError(
+                f"strategy must be one of {self._STRATEGIES}, got {strategy!r}"
+            )
         self._validate_score(model)
+
+        self.strategy = strategy
 
         if weights is not None:
             self.weights = weights
@@ -94,82 +117,64 @@ class WeightOptimizer(object):
         )
 
     def optimize(self, seq_aa):
-        raise Exception("not implemented")
+        """
+        Encode an amino acid sequence using the configured strategy.
+
+        Parameters
+        ----------
+        seq_aa : str
+            Amino acid sequence.
+
+        Returns
+        -------
+        str
+            DNA sequence.
+        """
+        candidates = self._get_seq_candidates(seq_aa)
+        if self.strategy == "max":
+            return "".join(
+                candidates.loc[candidates.groupby("pos")["weights"].idxmax(), "codon"]
+            )
+        if self.strategy == "min":
+            return "".join(
+                candidates.loc[candidates.groupby("pos")["weights"].idxmin(), "codon"]
+            )
+        # 'balanced'
+        return "".join(
+            candidates.groupby("pos").apply(
+                lambda df: df.sample(n=1, weights="weights")
+            )["codon"]
+        )
+
+
+def _deprecated_optimizer(strategy, old_name):
+    warnings.warn(
+        f"{old_name} is deprecated; use WeightOptimizer(strategy={strategy!r}) "
+        "instead. Will be removed in v0.6.0.",
+        FutureWarning,
+        stacklevel=3,
+    )
 
 
 class MaxWeight(WeightOptimizer):
-    """
-    Optimizes the amino acid sequence by selecting synonymous codons with
-    the highest weights.
+    """Deprecated. Use ``WeightOptimizer(strategy='max')``."""
 
-    Parameters
-    ----------
-    weights : pd.Series, optional
-        Codon weights, according to which optimization will encode the
-        sequence, by default None
-    model : scores.ScalarScore, optional
-        Codon model object with a `weights` property, by default None
-    higher_is_better : bool, optional
-        Defines the direction of the weights for the optimization, by
-        default True
-    genetic_code : int, optional
-        NCBI genetic code ID, by default 1
-    """
-
-    def optimize(self, seq_aa):
-        weights = self._get_seq_candidates(seq_aa)
-        return "".join(weights.loc[weights.groupby("pos")["weights"].idxmax(), "codon"])
+    def __init__(self, **kwargs):
+        _deprecated_optimizer("max", "MaxWeight")
+        super().__init__(strategy="max", **kwargs)
 
 
 class MinWeight(WeightOptimizer):
-    """
-    Optimizes the amino acid sequence by selecting synonymous codons with
-    the lowest weights.
+    """Deprecated. Use ``WeightOptimizer(strategy='min')``."""
 
-    Parameters
-    ----------
-    weights : pd.Series, optional
-        Codon weights, according to which optimization will encode the
-        sequence, by default None
-    model : scores.ScalarScore, optional
-        Codon model object with a `weights` property, by default None
-    higher_is_better : bool, optional
-        Defines the direction of the weights for the optimization, by
-        default True
-    genetic_code : int, optional
-        NCBI genetic code ID, by default 1
-    """
-
-    def optimize(self, seq_aa):
-        weights = self._get_seq_candidates(seq_aa)
-        return "".join(weights.loc[weights.groupby("pos")["weights"].idxmin(), "codon"])
+    def __init__(self, **kwargs):
+        _deprecated_optimizer("min", "MinWeight")
+        super().__init__(strategy="min", **kwargs)
 
 
 class BalancedWeight(WeightOptimizer):
-    """
-    Optimizes the amino acid sequence by selecting synonymous codons with
-    a probability proportional to their weight. This generates a balanced
-    codon distribution, with more optimal codons appearing at higher
-    frequencies.
+    """Deprecated. Use ``WeightOptimizer(strategy='balanced')``."""
 
-    Parameters
-    ----------
-    weights : pd.Series, optional
-        Codon weights, according to which optimization will encode the
-        sequence, by default None
-    model : scores.ScalarScore, optional
-        Codon model object with a `weights` property, by default None
-    higher_is_better : bool, optional
-        Defines the direction of the weights for the optimization, by
-        default True
-    genetic_code : int, optional
-        NCBI genetic code ID, by default 1
-    """
-
-    def optimize(self, seq_aa):
-        weights = self._get_seq_candidates(seq_aa)
-        return "".join(
-            weights.groupby("pos").apply(lambda df: df.sample(n=1, weights="weights"))[
-                "codon"
-            ]
-        )
+    def __init__(self, **kwargs):
+        _deprecated_optimizer("balanced", "BalancedWeight")
+        super().__init__(strategy="balanced", **kwargs)

--- a/tests/optimizers/test_weight_optimizer.py
+++ b/tests/optimizers/test_weight_optimizer.py
@@ -1,0 +1,99 @@
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from codonbias import stats
+from codonbias.optimizers import (
+    BalancedWeight,
+    MaxWeight,
+    MinWeight,
+    WeightOptimizer,
+)
+
+
+@pytest.fixture
+def codon_weights():
+    """Reproducible random codon weights for the standard genetic code."""
+    codons = stats.gc[["1"]].reset_index().rename(columns={"1": "aa", "index": "codon"})
+    codons = codons[codons["aa"] != "*"]
+    rng = np.random.default_rng(7)
+    return pd.Series(
+        rng.random(len(codons)),
+        index=codons["codon"].values,
+        name="weights",
+    )
+
+
+@pytest.fixture
+def aa_seq():
+    return "MKLAFIPVTRGYHN"
+
+
+@pytest.mark.parametrize("strategy", ["max", "min", "balanced"])
+def test_optimize_returns_codon_string_of_correct_length(
+    codon_weights, aa_seq, strategy
+):
+    np.random.seed(0)
+    out = WeightOptimizer(strategy=strategy, weights=codon_weights).optimize(aa_seq)
+    assert isinstance(out, str)
+    assert len(out) == 3 * len(aa_seq)
+
+
+def test_max_picks_higher_weight_than_min(codon_weights, aa_seq):
+    """Per-position, the 'max' codon weight must be >= the 'min' codon weight."""
+    opt_max = WeightOptimizer(strategy="max", weights=codon_weights)
+    opt_min = WeightOptimizer(strategy="min", weights=codon_weights)
+    seq_max = opt_max.optimize(aa_seq)
+    seq_min = opt_min.optimize(aa_seq)
+
+    w = opt_max.weights.set_index("codon")["weights"]
+    for i in range(len(aa_seq)):
+        c_max = seq_max[3 * i : 3 * (i + 1)]
+        c_min = seq_min[3 * i : 3 * (i + 1)]
+        assert w[c_max] >= w[c_min]
+
+
+def test_balanced_is_deterministic_under_numpy_seed(codon_weights, aa_seq):
+    opt = WeightOptimizer(strategy="balanced", weights=codon_weights)
+    np.random.seed(0)
+    a = opt.optimize(aa_seq)
+    np.random.seed(0)
+    b = opt.optimize(aa_seq)
+    assert a == b
+
+
+def test_unknown_strategy_raises(codon_weights):
+    with pytest.raises(ValueError, match="strategy must be one of"):
+        WeightOptimizer(strategy="best", weights=codon_weights)
+
+
+def test_missing_weights_and_model_raises():
+    with pytest.raises(TypeError, match="weights"):
+        WeightOptimizer(strategy="max")
+
+
+@pytest.mark.parametrize(
+    ("shim_cls", "strategy"),
+    [
+        (MaxWeight, "max"),
+        (MinWeight, "min"),
+        (BalancedWeight, "balanced"),
+    ],
+)
+def test_shim_emits_future_warning_and_matches_new_api(
+    codon_weights, aa_seq, shim_cls, strategy
+):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        np.random.seed(0)
+        shim_out = shim_cls(weights=codon_weights).optimize(aa_seq)
+
+    assert any(issubclass(w.category, FutureWarning) for w in caught), (
+        f"{shim_cls.__name__} did not emit FutureWarning"
+    )
+
+    np.random.seed(0)
+    new_out = WeightOptimizer(strategy=strategy, weights=codon_weights).optimize(aa_seq)
+    assert shim_out == new_out


### PR DESCRIPTION
## Summary

- Collapses `MaxWeight` / `MinWeight` / `BalancedWeight` (each a 1-line `optimize()` override) into `WeightOptimizer(strategy="max" | "min" | "balanced")`. Dispatch lives in `WeightOptimizer.optimize`. Surface area drops from four classes to one, and a future strategy is a new branch rather than a new class.
- Old class names kept as thin shims that emit `FutureWarning` ("will be removed in v0.6.0") and delegate to the base, so existing user code keeps working with a single audible warning.
- Adds `tests/optimizers/test_weight_optimizer.py` (the optimizers module previously had no tests): covers the three strategies, the `unknown strategy` and missing-weights error paths, balanced-mode determinism under a numpy seed, and shim parity with the new API.

Candidate 1 from `issue_module_depth.md`. The deprecation pattern (FutureWarning + remove-in-0.6.0) will be reused for candidate 2.

## Test plan

- [x] `ruff format codonbias/ tests/` clean
- [x] `ruff check codonbias/ tests/` clean
- [x] `pytest tests/optimizers/` — 10/10 pass
- [x] Smoke check confirming shim output matches new API under identical numpy seeds and that `FutureWarning` is emitted
- [ ] CI green