### PR TITLE
refactor: promote CodonCounter and BaseCounter internals to public surface

### DIFF
--- a/codonbias/scores.py
+++ b/codonbias/scores.py
@@ -265,10 +265,10 @@ class FrequencyOfOptimalCodons(ScalarScore, VectorScore):
         self.weights[self.weights >= self.thresh] = 1  # optimal
         self.weights[self.weights < self.thresh] = 0  # non-optimal
         self.weights = self.weights.droplevel("aa")
-        self._weights_arr = self.weights.reindex(self.counter._idx_to_codon).values
+        self._weights_arr = self.weights.reindex(self.counter.codon_index).values
 
     def _calc_score(self, seq):
-        counts, _ = self.counter._count_single(seq)
+        counts = self.counter.count_array(seq)
         mask = np.isfinite(self._weights_arr)
         return (self._weights_arr[mask] * counts[mask]).sum() / counts[mask].sum()
 
@@ -434,7 +434,7 @@ class CodonAdaptationIndex(ScalarScore, VectorScore):
 
     def _calc_score(self, seq):
         if self.k_mer == 1:
-            counts, _ = self.counter._count_single(seq)
+            counts = self.counter.count_array(seq)
             mask = np.isfinite(self._log_weights_arr)
             return np.exp(
                 (self._log_weights_arr[mask] * counts[mask]).sum() / counts[mask].sum()
@@ -463,7 +463,7 @@ class CodonAdaptationIndex(ScalarScore, VectorScore):
 
         if self.k_mer == 1:
             self._log_weights_arr = self.log_weights.reindex(
-                self.counter._idx_to_codon
+                self.counter.codon_index
             ).values
 
 
@@ -828,7 +828,7 @@ class TrnaAdaptationIndex(ScalarScore, VectorScore):
         self.weights = self._calc_weights()
         self.log_weights = np.log(self.weights)
         self._log_weights_arr = self.log_weights.reindex(
-            self.counter._idx_to_codon
+            self.counter.codon_index
         ).values
 
     def optimize_s_values(
@@ -871,7 +871,7 @@ class TrnaAdaptationIndex(ScalarScore, VectorScore):
             self.weights = self._calc_weights()
             self.log_weights = np.log(self.weights)
             self._log_weights_arr = self.log_weights.reindex(
-                self.counter._idx_to_codon
+                self.counter.codon_index
             ).values
             return -stats.spearmanr(self.get_score(ref_seq), expression).statistic
 
@@ -920,7 +920,7 @@ class TrnaAdaptationIndex(ScalarScore, VectorScore):
         return weights
 
     def _calc_score(self, seq):
-        counts, _ = self.counter._count_single(seq)
+        counts = self.counter.count_array(seq)
         mask = np.isfinite(self._log_weights_arr)
         return np.exp(
             (self._log_weights_arr[mask] * counts[mask]).sum() / counts[mask].sum()
@@ -1295,11 +1295,11 @@ class NormalizedTranslationalEfficiency(ScalarScore, VectorScore):
 
         self.counter = CodonCounter(genetic_code=genetic_code, ignore_stop=True)
         self._log_weights_arr = self.log_weights.reindex(
-            self.counter._idx_to_codon
+            self.counter.codon_index
         ).values
 
     def _calc_score(self, seq):
-        counts, _ = self.counter._count_single(seq)
+        counts = self.counter.count_array(seq)
         mask = np.isfinite(self._log_weights_arr)
         return np.exp(
             (self._log_weights_arr[mask] * counts[mask]).sum() / counts[mask].sum()

--- a/codonbias/scores.py
+++ b/codonbias/scores.py
@@ -560,9 +560,9 @@ class EffectiveNumberOfCodons(ScalarScore, WeightScore):
                 dtype=np.int8,
             )
             self._aa_deg = np.bincount(
-                self.counter._aa_group, minlength=self.counter._n_aa
+                self.counter.aa_group, minlength=self.counter.n_aa
             )
-            self._bcc_uniform = 1.0 / self._aa_deg[self.counter._aa_group]
+            self._bcc_uniform = 1.0 / self._aa_deg[self.counter.aa_group]
             # Reused on every bg_correction=True sequence to skip the
             # pd.Series wrapping of BaseCounter.count()/get_table().
             self._base_counter = BaseCounter()
@@ -662,11 +662,10 @@ class EffectiveNumberOfCodons(ScalarScore, WeightScore):
         P: 1D array of shape (n_codons,) representing relative frequency of each codon w.r.t its group
         N: 1D array of shape (n_aa,) containing the total absolute counts of each AA observed in the sequence
         """
-        counts, _ = self.counter._count_single(seq)
-        counts = counts + self.pseudocount
-        aa_group = self.counter._aa_group
+        counts = self.counter.count_array(seq) + self.pseudocount
+        aa_group = self.counter.aa_group
 
-        N = np.bincount(aa_group, weights=counts, minlength=self.counter._n_aa)
+        N = np.bincount(aa_group, weights=counts, minlength=self.counter.n_aa)
 
         # Safely divide, leaving NaN where N is 0
         with np.errstate(divide="ignore", invalid="ignore"):
@@ -687,7 +686,7 @@ class EffectiveNumberOfCodons(ScalarScore, WeightScore):
         # Pandas .sum() ignores NaNs by default. We mimic this by masking NaNs before bincount.
         valid_chi2 = ~np.isnan(chi2)
         chi2_aa = np.bincount(
-            aa_group[valid_chi2], weights=chi2[valid_chi2], minlength=self.counter._n_aa
+            aa_group[valid_chi2], weights=chi2[valid_chi2], minlength=self.counter.n_aa
         )
 
         if not self.robust:
@@ -705,7 +704,7 @@ class EffectiveNumberOfCodons(ScalarScore, WeightScore):
         pd.Series (legacy fallback used by the k_mer>1 _calc_BCC path).
         """
         if self.k_mer == 1:
-            counts = self._base_counter._count_single(seq).astype(float) + 1
+            counts = self._base_counter.count_array(seq).astype(float) + 1
             counts /= counts.sum()
             return counts
         return BaseCounter(seq).get_table(normed=True)
@@ -716,11 +715,11 @@ class EffectiveNumberOfCodons(ScalarScore, WeightScore):
             # BNC is an ndarray in ACGT order from _calc_BNC's k_mer=1 path.
             bcc = BNC[self._codon_base_idx].prod(axis=1)
             aa_sums = np.bincount(
-                self.counter._aa_group,
+                self.counter.aa_group,
                 weights=bcc,
-                minlength=self.counter._n_aa,
+                minlength=self.counter.n_aa,
             )
-            bcc = bcc / aa_sums[self.counter._aa_group]
+            bcc = bcc / aa_sums[self.counter.aa_group]
             return pd.Series(bcc, index=self.template.index, name="bcc")
 
         BCC = self.template.copy()
@@ -1188,7 +1187,7 @@ class RelativeCodonBiasScore(ScalarScore, VectorScore, WeightScore):
         """
         BNC = np.empty((4, 3), dtype=int)
         for pos in range(3):
-            BNC[:, pos] = self._base_counter._count_single(seq[pos::3])
+            BNC[:, pos] = self._base_counter.count_array(seq[pos::3])
         return BNC
 
     def _calc_BCC(self, BNC):

--- a/codonbias/stats.py
+++ b/codonbias/stats.py
@@ -83,12 +83,6 @@ class CodonCounter(object):
         self._aa_to_idx = {aa: i for i, aa in enumerate(unique_aa)}
         self.aa_group = np.array([self._aa_to_idx[aa] for aa in code["aa"]])
 
-        # Transit aliases for the renamed attrs. Removed once all callers
-        # migrate to the public names.
-        self._idx_to_codon = self.codon_index
-        self._n_aa = self.n_aa
-        self._aa_group = self.aa_group
-
         # Base-5 packed codon LUT for the vectorised k_mer=1 path. Codon
         # ids are packed b0*25 + b1*5 + b2 so sentinel-containing triplets
         # never collide with valid ACGT triplets.
@@ -163,40 +157,26 @@ class CodonCounter(object):
         return self
 
     def _count(self, seqs):
+        if self.k_mer == 1:
+            if isinstance(seqs, str):
+                return self.count_array(seqs)
+            if isinstance(seqs, (list, np.ndarray)):
+                counts = np.column_stack([self.count_array(s) for s in seqs])
+                return counts.sum(axis=1) if self.sum_seqs else counts
+            raise ValueError(f"unknown sequence type: {type(seqs)}")
+
+        # k_mer > 1: pandas/Counter fallback
         if isinstance(seqs, str):
-            res = self._count_single(seqs)
-            return (
-                res[0] if self.k_mer == 1 else res
-            )  # Return only count array for k_mer=1
-        elif isinstance(seqs, (list, np.ndarray)):
-            if self.k_mer == 1:
-                counts = np.column_stack([self._count_single(s)[0] for s in seqs])
-            else:
-                counts = pd.concat(
-                    [self._count_single(s) for s in seqs], axis=1
-                ).fillna(0)
+            return self._count_kmer_n(seqs)
+        if isinstance(seqs, (list, np.ndarray)):
+            counts = pd.concat([self._count_kmer_n(s) for s in seqs], axis=1).fillna(0)
             return counts.sum(axis=1) if self.sum_seqs else counts
         raise ValueError(f"unknown sequence type: {type(seqs)}")
 
-    def _count_single(self, seq):
+    def _count_kmer_n(self, seq):
         if not isinstance(seq, str):
             raise ValueError(f"sequence is not a string: {type(seq)}")
         seq = seq.upper().replace("U", "T")
-
-        if self.k_mer == 1:
-            b = seq.encode("ascii", errors="replace")
-            n_codons = len(b) // 3
-            arr = np.frombuffer(b[: n_codons * 3], dtype=np.uint8).reshape(n_codons, 3)
-            base_ids = _BASE_LUT[arr]
-            lex_ids = base_ids[:, 0] * 25 + base_ids[:, 1] * 5 + base_ids[:, 2]
-            aa_ids = self._codon_lex_to_aa[lex_ids]
-            valid = aa_ids >= 0
-            counts = np.bincount(aa_ids[valid], minlength=len(self.codon_index)).astype(
-                float
-            )
-            aa_counts = np.bincount(self.aa_group, weights=counts, minlength=self.n_aa)
-            return counts, aa_counts
-
         return pd.Series(
             Counter(iter_codons(seq, k_mer=self.k_mer)),
             dtype=int,
@@ -472,36 +452,31 @@ class BaseCounter(object):
         return self
 
     def _count(self, seqs):
+        if self.k_mer == 1:
+            if isinstance(seqs, str):
+                return self.count_array(seqs)
+            if isinstance(seqs, (list, np.ndarray)):
+                counts = np.column_stack([self.count_array(s) for s in seqs])
+                return counts.sum(axis=1) if self.sum_seqs else counts
+            raise ValueError(f"unknown sequence type: {type(seqs)}")
+
+        # k_mer > 1: pandas/Counter fallback
         if isinstance(seqs, str):
-            return self._count_single(seqs)
-        elif isinstance(seqs, (list, np.ndarray)):
-            if self.k_mer == 1:
-                counts = np.column_stack([self._count_single(s) for s in seqs])
-            else:
-                counts = pd.concat(
-                    [self._count_single(s) for s in seqs], axis=1
-                ).fillna(0)
+            return self._count_kmer_n(seqs)
+        if isinstance(seqs, (list, np.ndarray)):
+            counts = pd.concat([self._count_kmer_n(s) for s in seqs], axis=1).fillna(0)
             return counts.sum(axis=1) if self.sum_seqs else counts
         raise ValueError(f"unknown sequence type: {type(seqs)}")
 
-    def _count_single(self, seq):
+    def _count_kmer_n(self, seq):
         if not isinstance(seq, str):
             raise ValueError(f"sequence is not a string: {type(seq)}")
         seq = seq.upper().replace("U", "T")
-
-        if self.k_mer == 1:
-            b = seq.encode("ascii", errors="replace")
-            arr = np.frombuffer(b, dtype=np.uint8)[self.frame - 1 :: self.step]
-            base_ids = _BASE_LUT[arr]
-            return np.bincount(base_ids[base_ids < 4], minlength=4)
-
         last_pos = len(seq) - self.k_mer + 1
         return pd.Series(
             Counter(
-                [
-                    seq[i : i + self.k_mer]
-                    for i in range(self.frame - 1, last_pos, self.step)
-                ]
+                seq[i : i + self.k_mer]
+                for i in range(self.frame - 1, last_pos, self.step)
             ),
             dtype=int,
         )

--- a/codonbias/stats.py
+++ b/codonbias/stats.py
@@ -75,25 +75,62 @@ class CodonCounter(object):
 
         code = code.sort_values(["aa", "codon"])
 
-        self._idx_to_codon = code["codon"].tolist()
-        self._codon_to_idx = {c: i for i, c in enumerate(self._idx_to_codon)}
+        self.codon_index = code["codon"].tolist()
+        self._codon_to_idx = {c: i for i, c in enumerate(self.codon_index)}
 
         unique_aa = code["aa"].unique()
-        self._n_aa = len(unique_aa)
+        self.n_aa = len(unique_aa)
         self._aa_to_idx = {aa: i for i, aa in enumerate(unique_aa)}
-        self._aa_group = np.array([self._aa_to_idx[aa] for aa in code["aa"]])
+        self.aa_group = np.array([self._aa_to_idx[aa] for aa in code["aa"]])
 
-        # Base-5 packed codon LUT for the vectorised k_mer=1 path in
-        # _count_single. Codon ids are packed b0*25 + b1*5 + b2 so
-        # sentinel-containing triplets never collide with valid ACGT triplets.
+        # Transit aliases for the renamed attrs. Removed once all callers
+        # migrate to the public names.
+        self._idx_to_codon = self.codon_index
+        self._n_aa = self.n_aa
+        self._aa_group = self.aa_group
+
+        # Base-5 packed codon LUT for the vectorised k_mer=1 path. Codon
+        # ids are packed b0*25 + b1*5 + b2 so sentinel-containing triplets
+        # never collide with valid ACGT triplets.
         self._codon_lex_to_aa = np.full(125, -1, dtype=np.int32)
-        for aa_idx, codon in enumerate(self._idx_to_codon):
+        for aa_idx, codon in enumerate(self.codon_index):
             lex = (
                 25 * "ACGT".index(codon[0])
                 + 5 * "ACGT".index(codon[1])
                 + "ACGT".index(codon[2])
             )
             self._codon_lex_to_aa[lex] = aa_idx
+
+    def count_array(self, seq):
+        """Stateless k_mer=1 codon count.
+
+        Returns an ndarray of shape ``(len(self.codon_index),)`` ordered
+        by ``self.codon_index``. Does not touch ``self.counts``.
+
+        Parameters
+        ----------
+        seq : str
+            DNA sequence.
+
+        Returns
+        -------
+        numpy.ndarray
+            Codon counts as float.
+        """
+        if self.k_mer != 1:
+            raise NotImplementedError("count_array is currently k_mer=1 only")
+        if not isinstance(seq, str):
+            raise ValueError(f"sequence is not a string: {type(seq)}")
+
+        seq = seq.upper().replace("U", "T")
+        b = seq.encode("ascii", errors="replace")
+        n_codons = len(b) // 3
+        arr = np.frombuffer(b[: n_codons * 3], dtype=np.uint8).reshape(n_codons, 3)
+        base_ids = _BASE_LUT[arr]
+        lex_ids = base_ids[:, 0] * 25 + base_ids[:, 1] * 5 + base_ids[:, 2]
+        aa_ids = self._codon_lex_to_aa[lex_ids]
+        valid = aa_ids >= 0
+        return np.bincount(aa_ids[valid], minlength=len(self.codon_index)).astype(float)
 
     def count(self, seqs):
         """
@@ -114,9 +151,9 @@ class CodonCounter(object):
         # MINIMAL CHANGE: Wrap NumPy back to Pandas at the boundary for k_mer=1
         if self.k_mer == 1:
             self.counts = (
-                pd.Series(res, index=self._idx_to_codon, name="count")
+                pd.Series(res, index=self.codon_index, name="count")
                 if res.ndim == 1
-                else pd.DataFrame(res, index=self._idx_to_codon)
+                else pd.DataFrame(res, index=self.codon_index)
             )
             self.counts.index.name = "codon"
         else:
@@ -154,12 +191,10 @@ class CodonCounter(object):
             lex_ids = base_ids[:, 0] * 25 + base_ids[:, 1] * 5 + base_ids[:, 2]
             aa_ids = self._codon_lex_to_aa[lex_ids]
             valid = aa_ids >= 0
-            counts = np.bincount(
-                aa_ids[valid], minlength=len(self._idx_to_codon)
-            ).astype(float)
-            aa_counts = np.bincount(
-                self._aa_group, weights=counts, minlength=self._n_aa
+            counts = np.bincount(aa_ids[valid], minlength=len(self.codon_index)).astype(
+                float
             )
+            aa_counts = np.bincount(self.aa_group, weights=counts, minlength=self.n_aa)
             return counts, aa_counts
 
         return pd.Series(
@@ -377,6 +412,33 @@ class BaseCounter(object):
         self.sum_seqs = sum_seqs
         if seqs is not None:
             self.count(seqs)
+
+    def count_array(self, seq):
+        """Stateless k_mer=1 base count.
+
+        Returns an ndarray of shape ``(4,)`` in ACGT order. Respects
+        ``self.frame`` and ``self.step``. Does not touch ``self.counts``.
+
+        Parameters
+        ----------
+        seq : str
+            Nucleotide sequence.
+
+        Returns
+        -------
+        numpy.ndarray
+            Base counts as int.
+        """
+        if self.k_mer != 1:
+            raise NotImplementedError("count_array is currently k_mer=1 only")
+        if not isinstance(seq, str):
+            raise ValueError(f"sequence is not a string: {type(seq)}")
+
+        seq = seq.upper().replace("U", "T")
+        b = seq.encode("ascii", errors="replace")
+        arr = np.frombuffer(b, dtype=np.uint8)[self.frame - 1 :: self.step]
+        base_ids = _BASE_LUT[arr]
+        return np.bincount(base_ids[base_ids < 4], minlength=4)
 
     def count(self, seqs):
         """

--- a/tests/scores/test_enc_regression.py
+++ b/tests/scores/test_enc_regression.py
@@ -169,7 +169,7 @@ def test_enc_weighted_filter_undersampled(k_mer, bg_correction):
 def test_enc_non_standard_genetic_code(genetic_code, bg_correction):
     """End-to-end smoke check on non-standard genetic codes.
 
-    The vectorised primitives (`CodonCounter._count_single` and
+    The vectorised primitives (`CodonCounter.count_array` and
     `_calc_BCC`) are unit-tested on codes 2 and 11 elsewhere; this
     test covers the full `get_score` pipeline to catch integration
     breakage on `genetic_code != 1`.

--- a/tests/stats/test_base_count_array.py
+++ b/tests/stats/test_base_count_array.py
@@ -1,10 +1,10 @@
-"""Equivalence tests for BaseCounter._count_single.
+"""Equivalence tests for BaseCounter.count_array.
 
 Compares the vectorised k_mer=1 implementation against an inline reference
-that reproduces the pre-vectorisation Python loop. The k_mer>1 path falls
-back to the same Counter-based code, so it's covered implicitly.
+that reproduces the pre-vectorisation Python loop. The k_mer>1 path uses
+Counter directly via the existing `count()` API and is covered separately.
 
-Mirrors the structure of tests/stats/test_count_single.py.
+Mirrors the structure of tests/stats/test_count_array.py.
 """
 
 from collections import Counter
@@ -16,7 +16,7 @@ import pytest
 from codonbias.stats import BaseCounter
 
 
-def _reference_count_single(counter, seq):
+def _reference_count_array(counter, seq):
     """Pre-vectorisation implementation, inlined here as the reference."""
     if not isinstance(seq, str):
         raise ValueError(f"sequence is not a string: {type(seq)}")
@@ -34,12 +34,7 @@ def _reference_count_single(counter, seq):
 
 
 def _canonical(counter, out):
-    """Normalise a raw _count_single output to a full-alphabet int Series.
-
-    k_mer=1 returns an ndarray in _init_table() order; k_mer>1 returns a
-    Counter-based Series missing unobserved keys. Both get canonicalised
-    to a Series indexed by _init_table() so they can be compared.
-    """
+    """Normalise a count output to a full-alphabet int Series for comparison."""
     idx = counter._init_table()
     if isinstance(out, np.ndarray):
         return pd.Series(out, index=idx).astype(int)
@@ -65,30 +60,37 @@ SEQS = {
 @pytest.mark.parametrize("name,seq", list(SEQS.items()))
 @pytest.mark.parametrize("step", [1, 3])
 @pytest.mark.parametrize("frame", [1, 2, 3])
-def test_count_single_kmer1_equivalence(name, seq, step, frame):
+def test_count_array_kmer1_equivalence(name, seq, step, frame):
     counter = BaseCounter(k_mer=1, step=step, frame=frame)
-    new = _canonical(counter, counter._count_single(seq))
-    ref = _canonical(counter, _reference_count_single(counter, seq))
+    new = _canonical(counter, counter.count_array(seq))
+    ref = _canonical(counter, _reference_count_array(counter, seq))
     pd.testing.assert_series_equal(new, ref, check_names=False)
 
 
-def test_count_single_rejects_non_string():
+def test_count_array_rejects_non_string():
     counter = BaseCounter()
     with pytest.raises(ValueError, match="sequence is not a string"):
-        counter._count_single(12345)
+        counter.count_array(12345)
 
 
-def test_count_single_return_types():
-    """Contract: ndarray for k_mer=1 (fast path), Series for k_mer>1 (fallback).
+def test_count_array_rejects_non_kmer_1():
+    counter = BaseCounter(k_mer=2)
+    with pytest.raises(NotImplementedError, match="k_mer=1"):
+        counter.count_array("ACGTACGT")
 
-    Matches CodonCounter._count_single's shape on its fast path.
-    """
-    out1 = BaseCounter(k_mer=1)._count_single("ACGTACGT")
-    assert isinstance(out1, np.ndarray)
-    assert out1.shape == (4,)
 
-    out2 = BaseCounter(k_mer=2)._count_single("ACGTACGT")
-    assert isinstance(out2, pd.Series)
+def test_count_array_does_not_mutate_state():
+    """count_array is stateless; self.counts must remain unset."""
+    counter = BaseCounter()
+    counter.count_array("ACGTACGT")
+    assert not hasattr(counter, "counts")
+
+
+def test_count_array_return_shape_and_dtype():
+    """Contract: ndarray of shape (4,) in ACGT order."""
+    out = BaseCounter().count_array("ACGTACGT")
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (4,)
 
 
 def test_count_kmer2_fallback_unchanged():
@@ -97,7 +99,7 @@ def test_count_kmer2_fallback_unchanged():
     for step, frame in [(1, 1), (2, 1), (1, 2)]:
         counter = BaseCounter(k_mer=2, step=step, frame=frame)
         got = counter.count(seq).counts.astype(int)
-        ref_raw = _reference_count_single(counter, seq)
+        ref_raw = _reference_count_array(counter, seq)
         expected = ref_raw.reindex(counter._init_table()).fillna(0).astype(int)
         pd.testing.assert_series_equal(got, expected, check_names=False)
 

--- a/tests/stats/test_count_array.py
+++ b/tests/stats/test_count_array.py
@@ -1,4 +1,4 @@
-"""Equivalence tests for CodonCounter._count_single.
+"""Equivalence tests for CodonCounter.count_array.
 
 Compares the vectorised implementation against an inline reference that
 reproduces the pre-vectorisation Python loop. Covers edge cases around
@@ -12,18 +12,18 @@ import pytest
 from codonbias.stats import CodonCounter
 
 
-def _reference_count_single(counter, seq):
+def _reference_count_array(counter, seq):
     """Pre-vectorisation implementation, inlined here as the reference."""
     if not isinstance(seq, str):
         raise ValueError(f"sequence is not a string: {type(seq)}")
     seq = seq.upper().replace("U", "T")
-    counts = np.zeros(len(counter._codon_to_idx), dtype=float)
+    codon_to_idx = {c: i for i, c in enumerate(counter.codon_index)}
+    counts = np.zeros(len(codon_to_idx), dtype=float)
     for i in range(0, len(seq) - 2, 3):
-        idx = counter._codon_to_idx.get(seq[i : i + 3])
+        idx = codon_to_idx.get(seq[i : i + 3])
         if idx is not None:
             counts[idx] += 1
-    aa_counts = np.bincount(counter._aa_group, weights=counts, minlength=counter._n_aa)
-    return counts, aa_counts
+    return counts
 
 
 SEQS = {
@@ -49,45 +49,51 @@ SEQS = {
 
 @pytest.mark.parametrize("name,seq", list(SEQS.items()))
 @pytest.mark.parametrize("ignore_stop", [True, False])
-def test_count_single_equivalence_genetic_code_1(name, seq, ignore_stop):
+def test_count_array_equivalence_genetic_code_1(name, seq, ignore_stop):
     counter = CodonCounter(ignore_stop=ignore_stop)
 
-    new_counts, new_aa = counter._count_single(seq)
-    ref_counts, ref_aa = _reference_count_single(counter, seq)
+    new_counts = counter.count_array(seq)
+    ref_counts = _reference_count_array(counter, seq)
 
     np.testing.assert_array_equal(
         new_counts, ref_counts, err_msg=f"counts mismatch on {name}"
     )
-    np.testing.assert_array_equal(
-        new_aa, ref_aa, err_msg=f"aa_counts mismatch on {name}"
-    )
 
 
 @pytest.mark.parametrize("genetic_code", [2, 11])
-def test_count_single_equivalence_other_genetic_codes(genetic_code):
+def test_count_array_equivalence_other_genetic_codes(genetic_code):
     """Non-standard genetic codes have different STOP sets — confirm the
-    LUT population respects the code-specific _idx_to_codon."""
+    LUT population respects the code-specific codon_index."""
     counter = CodonCounter(genetic_code=genetic_code, ignore_stop=True)
     seq = "ATGAAACCCGGGTTTTGATAATAGCTG"  # includes TGA / TAA / TAG
-    new_counts, new_aa = counter._count_single(seq)
-    ref_counts, ref_aa = _reference_count_single(counter, seq)
+    new_counts = counter.count_array(seq)
+    ref_counts = _reference_count_array(counter, seq)
     np.testing.assert_array_equal(new_counts, ref_counts)
-    np.testing.assert_array_equal(new_aa, ref_aa)
 
 
-def test_count_single_rejects_non_string():
+def test_count_array_rejects_non_string():
     counter = CodonCounter()
     with pytest.raises(ValueError, match="sequence is not a string"):
-        counter._count_single(12345)
+        counter.count_array(12345)
 
 
-def test_count_single_return_shape_and_dtype():
-    """Contract: (counts, aa_counts) tuple, float arrays, correct shapes."""
+def test_count_array_rejects_non_kmer_1():
+    counter = CodonCounter(k_mer=2)
+    with pytest.raises(NotImplementedError, match="k_mer=1"):
+        counter.count_array("ATGAAA")
+
+
+def test_count_array_does_not_mutate_state():
+    """count_array is stateless; self.counts must remain unset."""
+    counter = CodonCounter()
+    counter.count_array("ATGAAACCCGGG")
+    assert not hasattr(counter, "counts")
+
+
+def test_count_array_return_shape_and_dtype():
+    """Contract: float ndarray of shape (len(codon_index),)."""
     counter = CodonCounter()  # default: genetic_code=1, ignore_stop=True
-    counts, aa_counts = counter._count_single("ATGAAACCCGGG")
+    counts = counter.count_array("ATGAAACCCGGG")
     assert isinstance(counts, np.ndarray)
-    assert isinstance(aa_counts, np.ndarray)
     assert counts.dtype.kind == "f"
-    assert aa_counts.dtype.kind == "f"
-    assert counts.shape == (len(counter._idx_to_codon),)
-    assert aa_counts.shape == (counter._n_aa,)
+    assert counts.shape == (len(counter.codon_index),)


### PR DESCRIPTION
## Summary

Candidate 4 from \`issue_module_depth.md\`. The fast-path attrs and methods that scores reach into (\`_aa_group\`, \`_n_aa\`, \`_idx_to_codon\`, \`_count_single\`) were officially private but de-facto public — any rename silently broke ENC, RCB, FOP, CAI, tAI, nTE. This PR makes the seam real.

**Public surface added:**

\`CodonCounter\`:
- \`count_array(seq) -> np.ndarray\` — stateless k_mer=1 codon count, ordered by \`codon_index\`.
- \`codon_index\`, \`aa_group\`, \`n_aa\` — public renames.

\`BaseCounter\`:
- \`count_array(seq) -> np.ndarray\` — stateless k_mer=1 base count, shape (4,) ACGT.

Both \`count_array\` methods raise \`NotImplementedError\` for k_mer != 1.

**Removed:**

- \`CodonCounter._count_single\` and \`BaseCounter._count_single\` — k_mer=1 logic lives in \`count_array\`; k_mer>1 fallback folded into a single private \`_count_kmer_n\` helper per class.
- \`_idx_to_codon\`, \`_n_aa\`, \`_aa_group\` aliases — strictly private was always the contract; we just enforced it. No external callers should have been reaching for these (they were \`_\`-prefixed).
- The dead \`aa_counts\` second return from \`_count_single\` — every caller wrote \`counts, _ = ...\`.

**Migrations** (one commit per logical group):

- ENC and RCB: stop reaching for \`_aa_group\`/\`_n_aa\` and \`BaseCounter._count_single\`. Hold a private \`BaseCounter()\` instance for LUT-init cost; use \`.count_array\` on it.
- FOP, CAI, tAI, nTE: \`_idx_to_codon\` -> \`codon_index\`, \`_count_single(seq)[0]\` -> \`count_array(seq)\`.

**Tests:**

- \`tests/stats/test_count_single.py\` -> \`test_count_array.py\`; \`tests/stats/test_base_count_single.py\` -> \`test_base_count_array.py\`. Reference impls and fixtures rewritten against the public surface.
- New contract tests per file: \`count_array\` rejects k_mer != 1; \`count_array\` does not mutate \`self.counts\`.

**Caveats lifted by this PR:** none yet — RSCU/RCBS concurrency (the open caveat from 3) becomes trivially fixable in a follow-up because \`count_array\` is now stateless. That follow-up is its own coherent PR.

**Caveats still open:** k_mer>1 path remains pandas-based (no perf change). When it gets vectorised, \`count_array\` becomes the single computation entry point and the existing get_codon_table/get_aa_table can be lifted to take an external \`counts=\` argument. Out of scope here.

## Test plan

- [x] \`ruff format codonbias/ tests/\` clean
- [x] \`ruff check codonbias/ tests/\` clean
- [x] \`pytest\` (excl. perf) — 201 passed in 31s (from 197; +4 for the new contract tests)
- [x] No remaining references to deleted private attrs/methods in \`codonbias/\` or \`tests/\`
- [x] CI green