### PR TITLE
refactor: Permuter(scope=...) replaces IntraSeqPermuter/IntraPosPermuter

### DIFF
--- a/codonbias/random.py
+++ b/codonbias/random.py
@@ -11,26 +11,36 @@ from .utils import greater_equal, iter_codons, less_equal, rankdata, translate
 
 class Permuter(object):
     """
-    This general-prupose permuter generates random sequences by shuffling
-    codons within and between sequences while preserving a defined
-    property of the sequence. This null model can be used to return the
-    shuffled sequences, or to estimate the z-score / p-value of weight
-    vectors associated with the sequence.
+    Permuter that generates random sequences by shuffling codons across
+    or within sequences while preserving a defined property. This null
+    model can be used to return the shuffled sequences, or to estimate
+    the z-score / p-value of weight vectors associated with the sequence.
 
-    The property (or properties) to be preserved by the permutation
-    is defined using `property_func`. For example, the default
+    The property (or properties) to be preserved by the permutation is
+    defined using `property_func`. For example, the default
     `property_func` translates the sequence to amino acids, and therefore
-    the permutation preserves the amino acid sequence. However, arbitrary
-    properties may be defined. When `n_samples` equals zero, the permuter
-    attemps to estimate the z-scores and p-values without actually
-    permuting the sequences (very fast). This is especially useful and
-    accurate for computing z-scores. While the resulting p-values are
-    highly correlated with permutation results, they tend to be
-    lower than permutation p-values by 30% on average (but up to 60% lower
-    at most).
+    the permutation preserves the amino acid sequence. The `scope`
+    parameter further constrains permutation:
+
+    - ``"inter_seq"``: codons can swap freely between sequences within
+      the same property group (default; matches the original
+      ``Permuter`` behaviour).
+    - ``"intra_seq"``: codons stay within their original sequence,
+      shuffling only across positions within that sequence.
+    - ``"intra_pos"``: codons stay at their original position, shuffling
+      only across sequences sharing that position.
+
+    When `n_samples` equals zero, the permuter attempts to estimate the
+    z-scores and p-values without actually permuting the sequences (very
+    fast). This is especially useful and accurate for computing
+    z-scores. While the resulting p-values are highly correlated with
+    permutation results, they tend to be lower than permutation p-values
+    by 30% on average (but up to 60% lower at most).
 
     Parameters
     ----------
+    scope : {'inter_seq', 'intra_seq', 'intra_pos'}, optional
+        Permutation scope, by default 'inter_seq'.
     property_func : function, optional
         Property generating function that accepts a sequence as input and
         returns a pandas.DataFrame with propery columns, by default
@@ -46,28 +56,33 @@ class Permuter(object):
         will use the number of available cores, by default None
     kwargs :
         Parameters to be passed to the `property_func`.
-
-    See also
-    --------
-    codonbias.random.IntraSeqPermuter : Within-sequence permutation.
-    codonbias.random.IntraPosPermuter : Positional permutation.
     """
+
+    _SCOPE_TO_ADD_PROPERTIES = {
+        "inter_seq": [],
+        "intra_seq": ["id"],
+        "intra_pos": ["pos"],
+    }
 
     def __init__(
         self,
+        scope="inter_seq",
         property_func=translate,
-        add_properties=None,
         n_samples=100,
         random_state=42,
         n_jobs=None,
         **kwargs,
     ):
-        if add_properties is None:
-            add_properties = []
+        if scope not in self._SCOPE_TO_ADD_PROPERTIES:
+            raise ValueError(
+                f"scope must be one of {tuple(self._SCOPE_TO_ADD_PROPERTIES)}, "
+                f"got {scope!r}"
+            )
 
+        self.scope = scope
         self.property_func = property_func
         self.property_args = kwargs
-        self.add_properties = add_properties
+        self.add_properties = self._SCOPE_TO_ADD_PROPERTIES[scope]
         self.n_samples = n_samples
         self.random_state = random_state
 
@@ -483,125 +498,26 @@ class Permuter(object):
         )
 
 
+def _deprecated_permuter(scope, old_name):
+    warnings.warn(
+        f"{old_name} is deprecated; use Permuter(scope={scope!r}) instead. "
+        "Will be removed in v0.6.0.",
+        FutureWarning,
+        stacklevel=3,
+    )
+
+
 class IntraSeqPermuter(Permuter):
-    """
-    This permuter generates random sequences by shuffling the codons
-    within each sequence while preserving a defined property of the
-    sequence. This null model can be used to return the shuffled
-    sequences, or to estimate the z-score / p-value of weight vectors
-    associated with the sequence.
+    """Deprecated. Use ``Permuter(scope='intra_seq')``."""
 
-    The property (or properties) to be preserved by the permutation
-    is defined using `property_func`. For example, the default
-    `property_func` translates the sequence to amino acids, and therefore
-    the permutation preserves the amino acid sequence. However, arbitrary
-    properties may be defined. When `n_samples` equals zero, the permuter
-    attemps to estimate the z-scores and p-values without actually
-    permuting the sequences (very fast). This is especially useful and
-    accurate for computing z-scores. While the resulting p-values are
-    highly correlated with permutation results, they tend to be
-    lower than permutation p-values by 30% on average (but up to 60% lower
-    at most).
-
-    Parameters
-    ----------
-    property_func : function, optional
-        Property generating function that accepts a sequence as input and
-        returns a pandas.DataFrame with propery columns, by default
-        utils.translate
-    n_samples : int, optional
-        The numper of permutations to generate for each sequence. When
-        zero, the permuter attempts to estimate the z-scores and
-        p-values without actually permuting the sequences, by default 100
-    random_state : int, optional
-        Random seed for the permutation function, by default 42
-    n_jobs : int or None, optional
-        Number of parallel processes to run. When set to None the permuter
-        will use the number of available cores, by default None
-    kwargs :
-        Parameters to be passed to the `property_func`.
-
-    See also
-    --------
-    codonbias.random.Permuter : General-purpose permutation.
-    codonbias.random.IntraPosPermuter : Positional permutation.
-    """
-
-    def __init__(
-        self,
-        property_func=translate,
-        n_samples=100,
-        random_state=42,
-        n_jobs=None,
-        **kwargs,
-    ):
-        super().__init__(
-            property_func=property_func,
-            add_properties=["id"],
-            n_samples=n_samples,
-            random_state=random_state,
-            n_jobs=n_jobs,
-            **kwargs,
-        )
+    def __init__(self, **kwargs):
+        _deprecated_permuter("intra_seq", "IntraSeqPermuter")
+        super().__init__(scope="intra_seq", **kwargs)
 
 
 class IntraPosPermuter(Permuter):
-    """
-    This permuter generates random sequences by shuffling codons in each
-    position between all sequences while preserving a defined property of
-    the sequence. This null model can be used to return the shuffled
-    sequences, or to estimate the z-score / p-value of weight vectors
-    associated with the sequence.
+    """Deprecated. Use ``Permuter(scope='intra_pos')``."""
 
-    The property (or properties) to be preserved by the permutation
-    is defined using `property_func`. For example, the default
-    `property_func` translates the sequence to amino acids, and therefore
-    the permutation preserves the amino acid sequence. However, arbitrary
-    properties may be defined. When `n_samples` equals zero, the permuter
-    attemps to estimate the z-scores and p-values without actually
-    permuting the sequences (very fast). This is especially useful and
-    accurate for computing z-scores. While the resulting p-values are
-    highly correlated with permutation results, they tend to be
-    lower than permutation p-values by 30% on average (but up to 60% lower
-    at most).
-
-    Parameters
-    ----------
-    property_func : fuction, optional
-        Property generating function that accepts a sequence as input and
-        returns a pandas.DataFrame with propery columns, by default
-        utils.translate
-    n_samples : int, optional
-        The numper of permutations to generate for each sequence. When
-        zero, the permuter attempts to estimate the z-scores and
-        p-values without actually permuting the sequences, by default 100
-    random_state : int, optional
-        Random seed for the permutation function, by default 42
-    n_jobs : int or None, optional
-        Number of parallel processes to run. When set to None the permuter
-        will use the number of available cores, by default None
-    kwargs :
-        Parameters to be passed to the `property_func`.
-
-    See also
-    --------
-    codonbias.random.Permuter : General-purpose permutation.
-    codonbias.random.IntraSeqPermuter : Within-sequence permutation.
-    """
-
-    def __init__(
-        self,
-        property_func=translate,
-        n_samples=100,
-        random_state=42,
-        n_jobs=None,
-        **kwargs,
-    ):
-        super().__init__(
-            property_func=property_func,
-            add_properties=["pos"],
-            n_samples=n_samples,
-            random_state=random_state,
-            n_jobs=n_jobs,
-            **kwargs,
-        )
+    def __init__(self, **kwargs):
+        _deprecated_permuter("intra_pos", "IntraPosPermuter")
+        super().__init__(scope="intra_pos", **kwargs)

--- a/tests/random/test_permuter.py
+++ b/tests/random/test_permuter.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from codonbias.random import IntraSeqPermuter, Permuter
+from codonbias.random import Permuter
 
 
 @pytest.fixture
@@ -20,8 +20,8 @@ def seqs():
 
 def test_permuter_reproducibility(seqs):
     """Same ``random_state`` on the same input must produce bit-exact output."""
-    p1 = IntraSeqPermuter(n_samples=5, random_state=42, n_jobs=1)
-    p2 = IntraSeqPermuter(n_samples=5, random_state=42, n_jobs=1)
+    p1 = Permuter(scope="intra_seq", n_samples=5, random_state=42, n_jobs=1)
+    p2 = Permuter(scope="intra_seq", n_samples=5, random_state=42, n_jobs=1)
     out1 = p1.get_permuted_seq(seqs)
     out2 = p2.get_permuted_seq(seqs)
 
@@ -53,8 +53,8 @@ def test_permuter_independent_groups(seqs):
 
 def test_permuter_changes_with_random_state(seqs):
     """Different ``random_state`` values must produce different output."""
-    p1 = IntraSeqPermuter(n_samples=3, random_state=42, n_jobs=1)
-    p2 = IntraSeqPermuter(n_samples=3, random_state=7, n_jobs=1)
+    p1 = Permuter(scope="intra_seq", n_samples=3, random_state=42, n_jobs=1)
+    p2 = Permuter(scope="intra_seq", n_samples=3, random_state=7, n_jobs=1)
     out1 = p1.get_permuted_seq(seqs)
     out2 = p2.get_permuted_seq(seqs)
 
@@ -67,7 +67,9 @@ def test_permuter_no_global_state_pollution(seqs):
     before = np.random.random()
 
     np.random.seed(123)
-    IntraSeqPermuter(n_samples=3, random_state=42, n_jobs=1).get_permuted_seq(seqs)
+    Permuter(
+        scope="intra_seq", n_samples=3, random_state=42, n_jobs=1
+    ).get_permuted_seq(seqs)
     after = np.random.random()
 
     assert before == after, (
@@ -78,7 +80,7 @@ def test_permuter_no_global_state_pollution(seqs):
 def test_permuter_smoke_shape(seqs):
     """Smoke: output has one row per input sequence, `n_samples` columns."""
     n_samples = 7
-    p = IntraSeqPermuter(n_samples=n_samples, random_state=42, n_jobs=1)
+    p = Permuter(scope="intra_seq", n_samples=n_samples, random_state=42, n_jobs=1)
     out = p.get_permuted_seq(seqs)
 
     assert len(out) == len(seqs)

--- a/tests/random/test_scope.py
+++ b/tests/random/test_scope.py
@@ -1,0 +1,76 @@
+"""Permuter scope dispatch and deprecation-shim coverage.
+
+Verifies that:
+- Each scope maps to the correct internal `add_properties`.
+- Unknown scope values raise.
+- The deprecated `IntraSeqPermuter` / `IntraPosPermuter` shims emit
+  `FutureWarning` and produce output identical to the new API under
+  the same `random_state`.
+"""
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from codonbias.random import IntraPosPermuter, IntraSeqPermuter, Permuter
+
+
+@pytest.fixture
+def seqs():
+    """Multi-synonym Ala/Lys sequences (matches test_permuter.py fixture)."""
+    return [
+        "ATG" + "GCTGCCGCAGCG" * 3 + "AAAAAGAAAAAG" * 2,
+        "ATG" + "GCCGCAGCGGCT" * 3 + "AAGAAAAAGAAA" * 2,
+        "ATG" + "GCAGCGGCTGCC" * 3 + "AAAAAGAAGAAA" * 2,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("scope", "expected"),
+    [
+        ("inter_seq", []),
+        ("intra_seq", ["id"]),
+        ("intra_pos", ["pos"]),
+    ],
+)
+def test_scope_maps_to_add_properties(scope, expected):
+    p = Permuter(scope=scope, n_samples=1, random_state=42, n_jobs=1)
+    assert p.scope == scope
+    assert p.add_properties == expected
+
+
+def test_default_scope_is_inter_seq():
+    p = Permuter(n_samples=1, random_state=42, n_jobs=1)
+    assert p.scope == "inter_seq"
+    assert p.add_properties == []
+
+
+def test_unknown_scope_raises():
+    with pytest.raises(ValueError, match="scope must be one of"):
+        Permuter(scope="cross_pos", n_samples=1, random_state=42, n_jobs=1)
+
+
+@pytest.mark.parametrize(
+    ("shim_cls", "scope"),
+    [
+        (IntraSeqPermuter, "intra_seq"),
+        (IntraPosPermuter, "intra_pos"),
+    ],
+)
+def test_shim_emits_future_warning_and_matches_new_api(seqs, shim_cls, scope):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        shim_out = shim_cls(n_samples=3, random_state=42, n_jobs=1).get_permuted_seq(
+            seqs
+        )
+
+    assert any(issubclass(w.category, FutureWarning) for w in caught), (
+        f"{shim_cls.__name__} did not emit FutureWarning"
+    )
+
+    new_out = Permuter(
+        scope=scope, n_samples=3, random_state=42, n_jobs=1
+    ).get_permuted_seq(seqs)
+
+    pd.testing.assert_frame_equal(shim_out, new_out)


### PR DESCRIPTION
## Summary

Candidate 2 from `issue_module_depth.md`. The two `Permuter` subclasses were subclass-as-config: each just passed a fixed `add_properties` to the base. Collapsing into one class with a `scope` kwarg removes ~120 lines of duplicated docstring boilerplate and makes the seam intentional rather than accidental.

- `Permuter(scope="inter_seq" | "intra_seq" | "intra_pos")`. Default `"inter_seq"` matches the original bare `Permuter` behaviour, so users of `Permuter(...)` see no change.
- `add_properties` is no longer a public constructor arg; the scope-to-`add_properties` mapping lives in a class-level dict.
- `IntraSeqPermuter` and `IntraPosPermuter` are now thin shims that emit `FutureWarning` and delegate to the base. They will be removed in v0.6.0.

## Test plan

- [x] `ruff format codonbias/ tests/` clean
- [x] `ruff check codonbias/ tests/` clean
- [x] Existing `tests/random/test_permuter.py` migrated from `IntraSeqPermuter(...)` to `Permuter(scope="intra_seq", ...)`. Five regression tests still pass on the new constructor form.
- [x] New `tests/random/test_scope.py`: scope dispatch (all three scopes + default), unknown-scope error, shim emits `FutureWarning` and matches new API output under same `random_state`.
- [x] Full suite: 208 passed (from 201; +7 for new scope tests).
- [ ] CI green

## Draft CHANGELOG entry (not committed)

Add to the next release under a fresh `## deprecations` section:

> - `IntraSeqPermuter` and `IntraPosPermuter` are deprecated in favour of `Permuter(scope="intra_seq" | "intra_pos")`. The old names emit `FutureWarning` and will be removed in v0.6.0.
> - `Permuter` no longer accepts the `add_properties` constructor arg directly; use `scope=` instead.