### PR TITLE
perf: stateless RSCU and RCBS via count_array

### DIFF
--- a/codonbias/scores.py
+++ b/codonbias/scores.py
@@ -349,38 +349,54 @@ class RelativeSynonymousCodonUsage(ScalarScore, VectorScore, WeightScore):
         self.reference = self.reference.get_aa_table(
             normed=True, pseudocount=pseudocount
         )
+        # Reference as ndarray in counter.codon_index order, for the
+        # vectorised _weights_and_counts path. Preserves the same numerical
+        # values the (aa, codon)-aligned Series gave previously.
+        self._reference_arr = (
+            self.reference.droplevel("aa").reindex(self.counter.codon_index).values
+        )
 
     def _calc_score(self, seq):
         D, counts = self._weights_and_counts(seq)
-        D = D.droplevel("aa")
-
         if self.mean == "geometric":
-            return geomean(np.log(D), counts) - 1
-        elif self.mean == "arithmetic":
-            return mean(D, counts)
-        else:
-            raise ValueError(f"unknown mean: {self.mean}")
+            log_D = np.log(D)
+            valid = np.isfinite(log_D)
+            return (
+                np.exp((log_D[valid] * counts[valid]).sum() / counts[valid].sum()) - 1
+            )
+        if self.mean == "arithmetic":
+            valid = np.isfinite(D)
+            return (D[valid] * counts[valid]).sum() / counts[valid].sum()
+        raise ValueError(f"unknown mean: {self.mean}")
 
     def _calc_vector(self, seq):
-        weights = self._calc_seq_weights(seq).droplevel("aa")
-        return weights.reindex(self._get_codon_vector(seq)).values
+        D, _ = self._weights_and_counts(seq)
+        # Map codon-indexed weights onto sequence positions; missing codons
+        # (e.g. STOPs when ignore_stop=True) yield NaN.
+        return (
+            pd.Series(D, index=self.counter.codon_index)
+            .reindex(self._get_codon_vector(seq))
+            .values
+        )
 
     def _calc_seq_weights(self, seq):
         D, _ = self._weights_and_counts(seq)
-        return D
+        # Public Series with the (aa, codon) MultiIndex matching `self.reference`.
+        return pd.Series(D, index=self.reference.index, name="weights")
 
     def _weights_and_counts(self, seq):
-        counter = self.counter.count(seq)
-        P = counter.get_aa_table(normed=True, pseudocount=self.pseudocount)
-        # codon weights
+        """Stateless. Returns (D, counts) as ndarrays in codon_index order."""
+        counts = self.counter.count_array(seq)
+        counts_pc = counts + self.pseudocount
+        aa_sums = np.bincount(
+            self.counter.aa_group, weights=counts_pc, minlength=self.counter.n_aa
+        )
+        P = counts_pc / aa_sums[self.counter.aa_group]
         if self.directional:
-            D = np.maximum(
-                P.divide(self.reference, axis=0), self.reference.divide(P, axis=0)
-            )
+            D = np.maximum(P / self._reference_arr, self._reference_arr / P)
         else:
-            D = P.divide(self.reference, axis=0)
-
-        return D, counter.counts
+            D = P / self._reference_arr
+        return D, counts
 
 
 class CodonAdaptationIndex(ScalarScore, VectorScore):

--- a/codonbias/scores.py
+++ b/codonbias/scores.py
@@ -1149,49 +1149,67 @@ class RelativeCodonBiasScore(ScalarScore, VectorScore, WeightScore):
         # Per-codon base indices for the vectorised _calc_BCC path. Row i
         # holds [b0, b1, b2] for codon i; column j is the base at position j.
         # Shape (64, 3) int8 = 192 B for any genetic code.
-        codons = ["".join(c) for c in product("ACGT", "ACGT", "ACGT")]
+        all_codons = ["".join(c) for c in product("ACGT", "ACGT", "ACGT")]
         base_to_idx = {"A": 0, "C": 1, "G": 2, "T": 3}
         self._codon_pos_idx = np.array(
-            [[base_to_idx[b] for b in cod] for cod in codons],
+            [[base_to_idx[b] for b in cod] for cod in all_codons],
             dtype=np.int8,
         )
-        self._bcc_index = pd.Index(codons, name="codon")
+        self._bcc_index = pd.Index(all_codons, name="codon")
+        # Map from counter.codon_index (length 61 by default) into the
+        # 64-codon BCC array, so BCC values can be subset to the active
+        # codon set after normalising over all 64. Preserves the prior
+        # numerical contract (BCC normalised over all 64 codons; STOPs
+        # contribute to the denominator but are never read).
+        codon_to_64idx = {c: i for i, c in enumerate(all_codons)}
+        self._bcc_idx_map = np.array(
+            [codon_to_64idx[c] for c in self.counter.codon_index], dtype=np.int32
+        )
         # Reused on every _calc_BNC call to skip BaseCounter's pandas
         # scaffolding. Same reach-through pattern ENC._calc_BNC uses.
         self._base_counter = BaseCounter()
 
     def _calc_score(self, seq):
         D, counts = self._weights_and_counts(seq)
-
         if self.mean == "geometric":
-            return geomean(np.log(D), counts) - 1
-        elif self.mean == "arithmetic":
-            return mean(D, counts)
-        else:
-            raise ValueError(f"unknown mean: {self.mean}")
+            log_D = np.log(D)
+            valid = np.isfinite(log_D)
+            return (
+                np.exp((log_D[valid] * counts[valid]).sum() / counts[valid].sum()) - 1
+            )
+        if self.mean == "arithmetic":
+            valid = np.isfinite(D)
+            return (D[valid] * counts[valid]).sum() / counts[valid].sum()
+        raise ValueError(f"unknown mean: {self.mean}")
 
     def _calc_vector(self, seq):
-        D = self._calc_seq_weights(seq)
-
-        return D.reindex(self._get_codon_vector(seq)).values
+        D, _ = self._weights_and_counts(seq)
+        return (
+            pd.Series(D, index=self.counter.codon_index)
+            .reindex(self._get_codon_vector(seq))
+            .values
+        )
 
     def _calc_seq_weights(self, seq):
         D, _ = self._weights_and_counts(seq)
-        return D
+        # Public Series indexed by all 64 codons (lex order, NaN at codons
+        # outside the active set). Preserves the prior pandas-alignment
+        # shape so external callers see no change.
+        full = pd.Series(np.nan, index=self._bcc_index, name="weights")
+        full.iloc[self._bcc_idx_map] = D
+        return full
 
     def _weights_and_counts(self, seq):
-        counter = self.counter.count(seq)
-        # background probabilities
+        """Stateless. Returns (D, counts) as ndarrays in codon_index order."""
+        counts = self.counter.count_array(seq)
+        counts_pc = counts + self.pseudocount
+        P = counts_pc / counts_pc.sum()
         BCC = self._calc_BCC(self._calc_BNC(seq))
-        # observed probabilities
-        P = counter.get_codon_table(normed=True, pseudocount=self.pseudocount)
-        # codon weights
         if self.directional:
             D = np.maximum(P / BCC, BCC / P)
         else:
             D = P / BCC
-
-        return D, counter.counts
+        return D, counts
 
     def _calc_BNC(self, seq):
         """Compute the per-position background nucleotide composition.
@@ -1209,15 +1227,18 @@ class RelativeCodonBiasScore(ScalarScore, VectorScore, WeightScore):
     def _calc_BCC(self, BNC):
         """Compute the background CODON composition of the sequence.
 
-        Position-aware product: for codon (b0, b1, b2),
-            BCC[cod] ∝ BNC[b0, 0] * BNC[b1, 1] * BNC[b2, 2]
-        then normalised to sum to 1. Equivalent to the previous
-        Series-indexed listcomp; preserves the raw-counts-then-normalise
-        semantics (no per-position pseudocount).
+        Position-aware product over all 64 codons, normalised over all 64
+        (preserving the prior denominator), then subset to the active
+        codon set in `counter.codon_index` order.
+
+        Returns
+        -------
+        numpy.ndarray
+            BCC in `counter.codon_index` order.
         """
-        bcc = BNC[self._codon_pos_idx, np.arange(3)].prod(axis=1).astype(float)
-        bcc /= bcc.sum()
-        return pd.Series(bcc, index=self._bcc_index)
+        bcc_full = BNC[self._codon_pos_idx, np.arange(3)].prod(axis=1).astype(float)
+        bcc_full /= bcc_full.sum()
+        return bcc_full[self._bcc_idx_map]
 
 
 class NormalizedTranslationalEfficiency(ScalarScore, VectorScore):

--- a/tests/scores/test_rcb_equivalence.py
+++ b/tests/scores/test_rcb_equivalence.py
@@ -76,7 +76,13 @@ def test_calc_bnc_equivalence(name, seq):
 
 @pytest.mark.parametrize("name,seq", list(SEQS.items()))
 def test_calc_bcc_equivalence(name, seq):
-    """Vectorised _calc_BCC matches the listcomp reference end-to-end."""
+    """Vectorised _calc_BCC matches the listcomp reference end-to-end.
+
+    The reference still produces the full 64-codon Series (lex order,
+    normalised over all 64). _calc_BCC now returns an ndarray subset to
+    `counter.codon_index` order, with the same denominator. Compare by
+    reindexing the reference onto `counter.codon_index`.
+    """
     rcb = RelativeCodonBiasScore()
     got = rcb._calc_BCC(rcb._calc_BNC(seq))
 
@@ -89,23 +95,24 @@ def test_calc_bcc_equivalence(name, seq):
         pytest.skip("singular per-position distribution — reference produces NaN")
 
     np.testing.assert_allclose(
-        got.values,
-        expected.reindex(got.index).values,
+        got,
+        expected.reindex(rcb.counter.codon_index).values,
         rtol=1e-12,
         err_msg=f"BCC mismatch on {name}",
     )
 
 
 def test_calc_bcc_return_shape():
-    """Contract: BCC is a Series indexed by 64 lex-ordered ACGT codons,
-    summing to 1 (when non-degenerate)."""
+    """Contract: BCC is an ndarray in `counter.codon_index` order; values
+    are read from a 64-codon normalisation but subset to the active
+    codon set, so they do not sum to 1 in general."""
     rcb = RelativeCodonBiasScore()
     BNC = rcb._calc_BNC("ATGAAACCCGGGTTTTAA" * 10)
     bcc = rcb._calc_BCC(BNC)
-    assert isinstance(bcc, pd.Series)
-    assert len(bcc) == 64
-    assert bcc.index[0] == "AAA" and bcc.index[-1] == "TTT"
-    np.testing.assert_allclose(bcc.sum(), 1.0, rtol=1e-12)
+    assert isinstance(bcc, np.ndarray)
+    assert bcc.shape == (len(rcb.counter.codon_index),)
+    # All-positive (BNC is positive everywhere on this seq).
+    assert (bcc > 0).all()
 
 
 def test_get_score_end_to_end_matches_prior_values():

--- a/tests/scores/test_rcb_regression.py
+++ b/tests/scores/test_rcb_regression.py
@@ -47,6 +47,13 @@ def test_rcb_basic_logic():
     assert np.isfinite(rcb.get_score("ATGATGATGATG"))
 
 
+def test_rcb_does_not_mutate_counter():
+    """Stateless contract: get_score must not populate self.counter.counts."""
+    rcb = RelativeCodonBiasScore()
+    rcb.get_score("ATGAAACCCGGGTTT")
+    assert not hasattr(rcb.counter, "counts")
+
+
 def test_rcb_multiple_input_types():
     rcb = RelativeCodonBiasScore()
     seqs = ["ATGCGTACG", "ATGATGATG"]

--- a/tests/scores/test_rscu.py
+++ b/tests/scores/test_rscu.py
@@ -1,0 +1,55 @@
+"""Regression and contract tests for RelativeSynonymousCodonUsage.
+
+The RSCU module previously had no dedicated tests; this file covers
+the basics: end-to-end finite output across parameter combinations,
+and the stateless contract on `self.counter` introduced when the
+score path moved to `count_array`.
+"""
+
+import numpy as np
+import pytest
+
+from codonbias.scores import RelativeSynonymousCodonUsage
+
+RSCU_COMBINATIONS = [
+    {"directional": False, "mean": "geometric"},
+    {"directional": False, "mean": "arithmetic"},
+    {"directional": True, "mean": "geometric"},
+    {"directional": True, "mean": "arithmetic"},
+]
+
+
+def format_param_id(p):
+    return f"dir_{p['directional']}-{p['mean']}"
+
+
+@pytest.mark.parametrize("params", RSCU_COMBINATIONS, ids=format_param_id)
+def test_rscu_basic_logic(params):
+    rscu = RelativeSynonymousCodonUsage(**params)
+    assert np.isfinite(rscu.get_score("ATGCGTACG"))
+    # Single-aa repeated codons are a degenerate but well-defined case.
+    assert np.isfinite(rscu.get_score("ATGATGATGATG"))
+
+
+def test_rscu_multiple_input_types():
+    rscu = RelativeSynonymousCodonUsage()
+    seqs = ["ATGCGTACG", "ATGATGATG"]
+    scores = rscu.get_score(seqs)
+    assert isinstance(scores, np.ndarray)
+    assert len(scores) == 2
+
+
+def test_rscu_does_not_mutate_counter():
+    """Stateless contract: get_score must not populate self.counter.counts."""
+    rscu = RelativeSynonymousCodonUsage()
+    rscu.get_score("ATGAAACCCGGGTTT")
+    assert not hasattr(rscu.counter, "counts")
+
+
+@pytest.mark.parametrize("genetic_code", [2, 11])
+def test_rscu_non_standard_genetic_code(genetic_code):
+    rscu = RelativeSynonymousCodonUsage(genetic_code=genetic_code)
+    seqs = ["ATGCGTACG" * 10, "ATGAAACCCGGGTTT" * 5, "ATGATGATGATGATG"]
+    scores = rscu.get_score(seqs)
+    assert scores.shape == (len(seqs),)
+    assert np.isfinite(scores).all()


### PR DESCRIPTION
## Summary

Closes the concurrency caveat that the candidate-3 PR (`fix: remove temporal coupling in RSCU/RCBS score computation`) flagged as out-of-scope, and as a side benefit unlocks a substantial perf gain. Now that `count_array` is stateless (from the candidate-4 PR), `RelativeSynonymousCodonUsage` and `RelativeCodonBiasScore` can compute everything as ndarray arithmetic with no shared `self.counter.counts` state.

**Behaviour changes:** none for `get_score` (numerically identical, E. coli regression CSVs unchanged) or `get_weights` (Series shapes preserved).

**Internal changes:**

- `RSCU._weights_and_counts`: pure ndarray; reference precomputed as `_reference_arr` in `__init__`.
- `RCBS._weights_and_counts`: pure ndarray; `_calc_BCC` returns ndarray in `counter.codon_index` order (still normalised over all 64 codons, then subset via `_bcc_idx_map`, preserving the prior numerical contract).
- `_calc_score` for both is pure-ndarray geomean/mean; `_calc_seq_weights` and `_calc_vector` keep their public Series shapes by wrapping at the boundary.

**Bench (10kb random seq, 200 iter, mean of 3 runs):**

| score | before | after | speedup |
|---|---:|---:|---:|
| RSCU | 220 ms | 6.4 ms | ~35x |
| RCB | 145 ms | 16 ms | ~9x |

Both classes now sit in the same ~6–16 ms band as ENC / FOP / CAI / tAI / nTE.

**New tests:**

- `tests/scores/test_rscu.py` (RSCU previously had no dedicated tests): basic-logic across the four `(directional x mean)` combinations, multi-input, no-mutation contract, non-standard genetic-code smoke (codes 2, 11).
- `test_rcb_regression.py` gains a no-mutation contract assertion.
- `test_rcb_equivalence.py` updated for `_calc_BCC`'s new ndarray return shape (the method is private; the tests were pinning the old shape).

## Test plan

- [x] `ruff format codonbias/ tests/` clean
- [x] `ruff check codonbias/ tests/` clean
- [x] `pytest` (excl. perf) — 217 passed (from 208; +9 for new tests)
- [x] E. coli regression CSVs unchanged on both RSCU (no prior CSVs) and RCB
- [x] Three bench runs each side; deltas reported above are stable
- [ ] CI green