### PR TITLE
refactor: extract geomean_array helper for k_mer=1 fast path

### DIFF
--- a/codonbias/scores.py
+++ b/codonbias/scores.py
@@ -9,6 +9,7 @@ from .stats import BaseCounter, CodonCounter
 from .utils import (
     fetch_GCN_from_GtRNAdb,
     geomean,
+    geomean_array,
     iter_codons,
     mean,
     reverse_complement,
@@ -451,10 +452,7 @@ class CodonAdaptationIndex(ScalarScore, VectorScore):
     def _calc_score(self, seq):
         if self.k_mer == 1:
             counts = self.counter.count_array(seq)
-            mask = np.isfinite(self._log_weights_arr)
-            return np.exp(
-                (self._log_weights_arr[mask] * counts[mask]).sum() / counts[mask].sum()
-            )
+            return geomean_array(self._log_weights_arr, counts)
         counts = self.counter.count(seq).counts
         return geomean(self.log_weights, counts)
 
@@ -927,10 +925,7 @@ class TrnaAdaptationIndex(ScalarScore, VectorScore):
 
     def _calc_score(self, seq):
         counts = self.counter.count_array(seq)
-        mask = np.isfinite(self._log_weights_arr)
-        return np.exp(
-            (self._log_weights_arr[mask] * counts[mask]).sum() / counts[mask].sum()
-        )
+        return geomean_array(self._log_weights_arr, counts)
 
     def _calc_vector(self, seq):
         return self.weights.reindex(self._get_codon_vector(seq)).values
@@ -1322,10 +1317,7 @@ class NormalizedTranslationalEfficiency(ScalarScore, VectorScore):
 
     def _calc_score(self, seq):
         counts = self.counter.count_array(seq)
-        mask = np.isfinite(self._log_weights_arr)
-        return np.exp(
-            (self._log_weights_arr[mask] * counts[mask]).sum() / counts[mask].sum()
-        )
+        return geomean_array(self._log_weights_arr, counts)
 
     def _calc_vector(self, seq):
         return self.weights.reindex(self._get_codon_vector(seq)).values

--- a/codonbias/utils.py
+++ b/codonbias/utils.py
@@ -103,6 +103,31 @@ def geomean(log_weights, counts):
     )
 
 
+def geomean_array(log_weights, counts):
+    """
+    Count-weighted geometric mean over aligned ndarray inputs.
+
+    Fast-path sibling of `geomean` for the k_mer=1 scoring path. Both
+    arrays must be aligned to the same codon order (typically
+    `counter.codon_index`); non-finite entries in `log_weights` are
+    masked out before the reduction.
+
+    Parameters
+    ----------
+    log_weights : numpy.ndarray
+        Codon scores in logarithmic scale, aligned to a fixed codon order.
+    counts : numpy.ndarray
+        Codon counts, aligned to the same codon order as `log_weights`.
+
+    Returns
+    -------
+    float
+        Geometric mean.
+    """
+    mask = np.isfinite(log_weights)
+    return np.exp((log_weights[mask] * counts[mask]).sum() / counts[mask].sum())
+
+
 def mean(weights, counts):
     """
     Compute the arithmetic mean based on codon scores given in


### PR DESCRIPTION
## Summary
- CAI, tAI and nTE each repeated the same count-weighted geometric mean inline (`np.exp((log_w[mask] * counts[mask]).sum() / counts[mask].sum())`) over an aligned `_log_weights_arr`. Lift it to `utils.geomean_array` as the ndarray sibling of the existing Series-based `geomean`.
- Names the domain primitive and removes the duplicated mask/exp boilerplate from three scoring sites. Closes the last open architecture-deepening candidate from the module-depth review.

## Test plan
- [x] `pytest tests/` — 228 passed (RSCU + RCB + ENC regression baselines unchanged).
- [x] `ruff format codonbias/ tests/` — clean.
- [x] `ruff check codonbias/ tests/` — clean.