### PR TITLE
perf: route everything through count_array; vectorise k_mer>1

### DIFF
--- a/codonbias/scores.py
+++ b/codonbias/scores.py
@@ -12,6 +12,7 @@ from .utils import (
     geomean_array,
     iter_codons,
     mean,
+    mean_array,
     reverse_complement,
 )
 
@@ -450,11 +451,8 @@ class CodonAdaptationIndex(ScalarScore, VectorScore):
         self._calc_weights(ref_seq)
 
     def _calc_score(self, seq):
-        if self.k_mer == 1:
-            counts = self.counter.count_array(seq)
-            return geomean_array(self._log_weights_arr, counts)
-        counts = self.counter.count(seq).counts
-        return geomean(self.log_weights, counts)
+        counts = self.counter.count_array(seq)
+        return geomean_array(self._log_weights_arr, counts)
 
     def _calc_vector(self, seq):
         return self.weights.reindex(
@@ -474,11 +472,9 @@ class CodonAdaptationIndex(ScalarScore, VectorScore):
         )
 
         self.log_weights = np.log(self.weights)
-
-        if self.k_mer == 1:
-            self._log_weights_arr = self.log_weights.reindex(
-                self.counter.codon_index
-            ).values
+        self._log_weights_arr = self.log_weights.reindex(
+            self.counter.kmer_index
+        ).values
 
 
 class EffectiveNumberOfCodons(ScalarScore, WeightScore):
@@ -983,11 +979,11 @@ class CodonPairBias(ScalarScore, VectorScore, WeightScore):
         self.pseudocount = pseudocount
 
         self.weights = self._calc_model_weights(ref_seq)
+        self._weights_arr = self.weights.reindex(self.counter.kmer_index).values
 
     def _calc_score(self, seq):
-        counts = self.counter.count(seq).counts
-
-        return mean(self.weights, counts)
+        counts = self.counter.count_array(seq)
+        return mean_array(self._weights_arr, counts)
 
     def _calc_vector(self, seq):
         return self.weights.reindex(

--- a/codonbias/scores.py
+++ b/codonbias/scores.py
@@ -8,10 +8,8 @@ from scipy import optimize, stats
 from .stats import BaseCounter, CodonCounter
 from .utils import (
     fetch_GCN_from_GtRNAdb,
-    geomean,
     geomean_array,
     iter_codons,
-    mean,
     mean_array,
     reverse_complement,
 )
@@ -472,9 +470,7 @@ class CodonAdaptationIndex(ScalarScore, VectorScore):
         )
 
         self.log_weights = np.log(self.weights)
-        self._log_weights_arr = self.log_weights.reindex(
-            self.counter.kmer_index
-        ).values
+        self._log_weights_arr = self.log_weights.reindex(self.counter.kmer_index).values
 
 
 class EffectiveNumberOfCodons(ScalarScore, WeightScore):

--- a/codonbias/stats.py
+++ b/codonbias/stats.py
@@ -188,7 +188,7 @@ class CodonCounter(object):
             CodonCounter object (self) with updated counts
         """
         res = self._count(seqs)
-        index = self.codon_index if self.k_mer == 1 else self._get_kmer_index()
+        index = self.kmer_index
         self.counts = (
             pd.Series(res, index=index, name="count")
             if res.ndim == 1
@@ -210,7 +210,16 @@ class CodonCounter(object):
             return counts.sum(axis=1) if self.sum_seqs else counts
         raise ValueError(f"unknown sequence type: {type(seqs)}")
 
-    def _get_kmer_index(self):
+    @property
+    def kmer_index(self):
+        """Concat-string index aligned to ``count_array``'s output order.
+
+        For k_mer=1 this is just ``codon_index``; for k_mer>1 it is the
+        lex product of ``codon_index`` joined into k-mer strings (e.g.,
+        ``['AAAAAA', 'AAAACC', ...]`` for k_mer=2). Built lazily.
+        """
+        if self.k_mer == 1:
+            return self.codon_index
         if not hasattr(self, "_kmer_index"):
             self._kmer_index = [
                 "".join(t) for t in product(self.codon_index, repeat=self.k_mer)

--- a/codonbias/stats.py
+++ b/codonbias/stats.py
@@ -83,17 +83,18 @@ class CodonCounter(object):
         self._aa_to_idx = {aa: i for i, aa in enumerate(unique_aa)}
         self.aa_group = np.array([self._aa_to_idx[aa] for aa in code["aa"]])
 
-        # Base-5 packed codon LUT for the vectorised k_mer=1 path. Codon
-        # ids are packed b0*25 + b1*5 + b2 so sentinel-containing triplets
-        # never collide with valid ACGT triplets.
-        self._codon_lex_to_aa = np.full(125, -1, dtype=np.int32)
-        for aa_idx, codon in enumerate(self.codon_index):
+        # Base-5 packed codon LUT for the vectorised path. Codon ids are
+        # packed b0*25 + b1*5 + b2 so sentinel-containing triplets never
+        # collide with valid ACGT triplets. Values are indices into
+        # ``codon_index`` (-1 for stops or sentinel-containing triplets).
+        self._codon_lex_to_idx = np.full(125, -1, dtype=np.int32)
+        for codon_idx, codon in enumerate(self.codon_index):
             lex = (
                 25 * "ACGT".index(codon[0])
                 + 5 * "ACGT".index(codon[1])
                 + "ACGT".index(codon[2])
             )
-            self._codon_lex_to_aa[lex] = aa_idx
+            self._codon_lex_to_idx[lex] = codon_idx
 
         # Per-codon base indices (A=0 C=1 G=2 T=3) for callers that need
         # to read background nucleotide compositions. Shape
@@ -133,9 +134,11 @@ class CodonCounter(object):
         arr = np.frombuffer(b[: n_codons * 3], dtype=np.uint8).reshape(n_codons, 3)
         base_ids = _BASE_LUT[arr]
         lex_ids = base_ids[:, 0] * 25 + base_ids[:, 1] * 5 + base_ids[:, 2]
-        aa_ids = self._codon_lex_to_aa[lex_ids]
-        valid = aa_ids >= 0
-        return np.bincount(aa_ids[valid], minlength=len(self.codon_index)).astype(float)
+        codon_ids = self._codon_lex_to_idx[lex_ids]
+        valid = codon_ids >= 0
+        return np.bincount(
+            codon_ids[valid], minlength=len(self.codon_index)
+        ).astype(float)
 
     def count(self, seqs):
         """

--- a/codonbias/stats.py
+++ b/codonbias/stats.py
@@ -5,8 +5,6 @@ from itertools import product
 import numpy as np
 import pandas as pd
 
-from .utils import iter_codons
-
 gc = pd.read_csv(
     f"{os.path.dirname(__file__)}/genetic_code_ncbi.csv", index_col=0
 ).sort_index()
@@ -174,6 +172,11 @@ class CodonCounter(object):
         Update the CodonCounter object with the codon counts of the given
         sequence(s).
 
+        Routes through ``count_array`` for the heavy lifting, then wraps
+        the resulting ndarray back into a pandas Series/DataFrame indexed
+        by the lex-product codon order. The MultiIndex split (when
+        ``concat_index=False``) is applied here as a presentation step.
+
         Parameters
         ----------
         seqs : str, or iterable of str
@@ -185,58 +188,34 @@ class CodonCounter(object):
             CodonCounter object (self) with updated counts
         """
         res = self._count(seqs)
-        # MINIMAL CHANGE: Wrap NumPy back to Pandas at the boundary for k_mer=1
-        if self.k_mer == 1:
-            self.counts = (
-                pd.Series(res, index=self.codon_index, name="count")
-                if res.ndim == 1
-                else pd.DataFrame(res, index=self.codon_index)
+        index = self.codon_index if self.k_mer == 1 else self._get_kmer_index()
+        self.counts = (
+            pd.Series(res, index=index, name="count")
+            if res.ndim == 1
+            else pd.DataFrame(res, index=index)
+        )
+        self.counts.index.name = "codon"
+        if self.k_mer > 1 and not self.concat_index:
+            self.counts.index = pd.MultiIndex.from_arrays(
+                [self.counts.index.str[3 * k : 3 * (k + 1)] for k in range(self.k_mer)],
+                names=[f"codon{k}" for k in range(self.k_mer)],
             )
-            self.counts.index.name = "codon"
-        else:
-            self.counts = self._format_counts(res)
-            if self.counts.ndim == 1:
-                self.counts = self.counts.rename("count")
         return self
 
     def _count(self, seqs):
-        if self.k_mer == 1:
-            if isinstance(seqs, str):
-                return self.count_array(seqs)
-            if isinstance(seqs, (list, np.ndarray)):
-                counts = np.column_stack([self.count_array(s) for s in seqs])
-                return counts.sum(axis=1) if self.sum_seqs else counts
-            raise ValueError(f"unknown sequence type: {type(seqs)}")
-
-        # k_mer > 1: pandas/Counter fallback
         if isinstance(seqs, str):
-            return self._count_kmer_n(seqs)
+            return self.count_array(seqs)
         if isinstance(seqs, (list, np.ndarray)):
-            counts = pd.concat([self._count_kmer_n(s) for s in seqs], axis=1).fillna(0)
+            counts = np.column_stack([self.count_array(s) for s in seqs])
             return counts.sum(axis=1) if self.sum_seqs else counts
         raise ValueError(f"unknown sequence type: {type(seqs)}")
 
-    def _count_kmer_n(self, seq):
-        if not isinstance(seq, str):
-            raise ValueError(f"sequence is not a string: {type(seq)}")
-        seq = seq.upper().replace("U", "T")
-        return pd.Series(
-            Counter(iter_codons(seq, k_mer=self.k_mer)),
-            dtype=int,
-        )
-
-    def _format_counts(self, counts):
-        counts.index.name = "codon"
-
-        if self.concat_index:
-            return counts
-
-        counts.index = pd.MultiIndex.from_arrays(
-            [counts.index.str[3 * k : 3 * (k + 1)] for k in range(self.k_mer)],
-            names=[f"codon{k}" for k in range(self.k_mer)],
-        )
-
-        return counts
+    def _get_kmer_index(self):
+        if not hasattr(self, "_kmer_index"):
+            self._kmer_index = [
+                "".join(t) for t in product(self.codon_index, repeat=self.k_mer)
+            ]
+        return self._kmer_index
 
     def get_codon_table(self, normed=False, pseudocount=1, nonzero=False):
         """

--- a/codonbias/stats.py
+++ b/codonbias/stats.py
@@ -108,10 +108,17 @@ class CodonCounter(object):
             )
 
     def count_array(self, seq):
-        """Stateless k_mer=1 codon count.
+        """Stateless k-mer codon count.
 
-        Returns an ndarray of shape ``(len(self.codon_index),)`` ordered
-        by ``self.codon_index``. Does not touch ``self.counts``.
+        Returns an ndarray of shape ``(len(self.codon_index) ** k_mer,)``
+        ordered by the lex product of ``self.codon_index`` (k_mer=1
+        reduces to ``self.codon_index``). K-mers containing a stop or
+        non-ACGT base are dropped, matching the observable output of
+        ``get_codon_table``. Does not touch ``self.counts``.
+
+        Supported for k_mer in [1, 3]; above that the dense aligned
+        output would require >14M entries per call and the method
+        raises ``NotImplementedError``.
 
         Parameters
         ----------
@@ -121,24 +128,46 @@ class CodonCounter(object):
         Returns
         -------
         numpy.ndarray
-            Codon counts as float.
+            Codon (or codon k-mer) counts as float.
         """
-        if self.k_mer != 1:
-            raise NotImplementedError("count_array is currently k_mer=1 only")
+        if self.k_mer > 3:
+            raise NotImplementedError(
+                f"count_array supports k_mer <= 3 (got k_mer={self.k_mer}); "
+                f"a dense aligned output would need "
+                f"{len(self.codon_index) ** self.k_mer:,} entries"
+            )
         if not isinstance(seq, str):
             raise ValueError(f"sequence is not a string: {type(seq)}")
 
         seq = seq.upper().replace("U", "T")
         b = seq.encode("ascii", errors="replace")
-        n_codons = len(b) // 3
-        arr = np.frombuffer(b[: n_codons * 3], dtype=np.uint8).reshape(n_codons, 3)
+        n_codons_total = len(b) // 3
+        arr = np.frombuffer(b[: n_codons_total * 3], dtype=np.uint8).reshape(
+            n_codons_total, 3
+        )
         base_ids = _BASE_LUT[arr]
         lex_ids = base_ids[:, 0] * 25 + base_ids[:, 1] * 5 + base_ids[:, 2]
         codon_ids = self._codon_lex_to_idx[lex_ids]
-        valid = codon_ids >= 0
-        return np.bincount(
-            codon_ids[valid], minlength=len(self.codon_index)
-        ).astype(float)
+
+        n_codons = len(self.codon_index)
+        n_out = n_codons**self.k_mer
+        if self.k_mer == 1:
+            valid = codon_ids >= 0
+            return np.bincount(codon_ids[valid], minlength=n_out).astype(float)
+
+        # k_mer in {2, 3}: sliding window over codon ids (stride 1, matching
+        # iter_codons step=3), then combine each window into a single bucket
+        # id ``sum(idx[i] * n_codons ** (k-1-i))`` for bincount. Windows that
+        # contain a stop/sentinel codon are dropped, mirroring the k_mer=1
+        # path.
+        k = self.k_mer
+        if n_codons_total < k:
+            return np.zeros(n_out, dtype=float)
+        windows = np.lib.stride_tricks.sliding_window_view(codon_ids, k)
+        valid = (windows >= 0).all(axis=1)
+        powers = n_codons ** np.arange(k - 1, -1, -1)
+        combined = (windows * powers).sum(axis=1)
+        return np.bincount(combined[valid], minlength=n_out).astype(float)
 
     def count(self, seqs):
         """

--- a/codonbias/stats.py
+++ b/codonbias/stats.py
@@ -1,5 +1,4 @@
 import os
-from collections import Counter
 from itertools import product
 
 import numpy as np
@@ -425,10 +424,13 @@ class BaseCounter(object):
             self.count(seqs)
 
     def count_array(self, seq):
-        """Stateless k_mer=1 base count.
+        """Stateless k-mer base count.
 
-        Returns an ndarray of shape ``(4,)`` in ACGT order. Respects
-        ``self.frame`` and ``self.step``. Does not touch ``self.counts``.
+        Returns an ndarray of shape ``(4 ** k_mer,)`` ordered by the lex
+        product of ACGT. Respects ``self.frame`` and ``self.step`` (which
+        select the *starting* positions of each k-mer; the k bases inside
+        each k-mer are always consecutive). K-mers containing any
+        non-ACGT base are dropped. Does not touch ``self.counts``.
 
         Parameters
         ----------
@@ -438,18 +440,33 @@ class BaseCounter(object):
         Returns
         -------
         numpy.ndarray
-            Base counts as int.
+            Base (or base k-mer) counts as int.
         """
-        if self.k_mer != 1:
-            raise NotImplementedError("count_array is currently k_mer=1 only")
         if not isinstance(seq, str):
             raise ValueError(f"sequence is not a string: {type(seq)}")
 
         seq = seq.upper().replace("U", "T")
         b = seq.encode("ascii", errors="replace")
-        arr = np.frombuffer(b, dtype=np.uint8)[self.frame - 1 :: self.step]
+        arr = np.frombuffer(b, dtype=np.uint8)
         base_ids = _BASE_LUT[arr]
-        return np.bincount(base_ids[base_ids < 4], minlength=4)
+
+        k = self.k_mer
+        n_out = 4**k
+        if k == 1:
+            strided = base_ids[self.frame - 1 :: self.step]
+            return np.bincount(strided[strided < 4], minlength=n_out)
+
+        # k_mer > 1: take all consecutive k-grams, then keep starts on the
+        # ``frame``/``step`` grid (matches the original Counter generator
+        # ``range(frame-1, last_pos, step)`` over ``seq[i:i+k]``).
+        if len(base_ids) < k:
+            return np.zeros(n_out, dtype=np.int64)
+        windows = np.lib.stride_tricks.sliding_window_view(base_ids, k)
+        windows = windows[self.frame - 1 :: self.step]
+        valid = (windows < 4).all(axis=1)
+        powers = 4 ** np.arange(k - 1, -1, -1)
+        combined = (windows * powers).sum(axis=1)
+        return np.bincount(combined[valid], minlength=n_out)
 
     def count(self, seqs):
         """
@@ -467,50 +484,35 @@ class BaseCounter(object):
             BaseCounter object (self) with updated counts
         """
         res = self._count(seqs)
-        if self.k_mer == 1:
-            # _count returns ndarray: (4,) for single/sum, (4, N) for multi.
-            index = list("ACGT")
-            self.counts = (
-                pd.Series(res, index=index, name="count")
-                if res.ndim == 1
-                else pd.DataFrame(res, index=index)
-            )
-        else:
-            self.counts = res.reindex(self._init_table()).fillna(0)
-            if self.counts.ndim == 1:
-                self.counts = self.counts.rename("count")
-
+        index = self.kmer_index
+        self.counts = (
+            pd.Series(res, index=index, name="count")
+            if res.ndim == 1
+            else pd.DataFrame(res, index=index)
+        )
         return self
 
     def _count(self, seqs):
-        if self.k_mer == 1:
-            if isinstance(seqs, str):
-                return self.count_array(seqs)
-            if isinstance(seqs, (list, np.ndarray)):
-                counts = np.column_stack([self.count_array(s) for s in seqs])
-                return counts.sum(axis=1) if self.sum_seqs else counts
-            raise ValueError(f"unknown sequence type: {type(seqs)}")
-
-        # k_mer > 1: pandas/Counter fallback
         if isinstance(seqs, str):
-            return self._count_kmer_n(seqs)
+            return self.count_array(seqs)
         if isinstance(seqs, (list, np.ndarray)):
-            counts = pd.concat([self._count_kmer_n(s) for s in seqs], axis=1).fillna(0)
+            counts = np.column_stack([self.count_array(s) for s in seqs])
             return counts.sum(axis=1) if self.sum_seqs else counts
         raise ValueError(f"unknown sequence type: {type(seqs)}")
 
-    def _count_kmer_n(self, seq):
-        if not isinstance(seq, str):
-            raise ValueError(f"sequence is not a string: {type(seq)}")
-        seq = seq.upper().replace("U", "T")
-        last_pos = len(seq) - self.k_mer + 1
-        return pd.Series(
-            Counter(
-                seq[i : i + self.k_mer]
-                for i in range(self.frame - 1, last_pos, self.step)
-            ),
-            dtype=int,
-        )
+    @property
+    def kmer_index(self):
+        """Concat-string index aligned to ``count_array``'s output order.
+
+        For k_mer=1 this is ``['A', 'C', 'G', 'T']``; for k_mer>1 it is
+        the lex product of ACGT joined into k-mer strings (e.g.,
+        ``['AA', 'AC', ..., 'TT']`` for k_mer=2). Built lazily.
+        """
+        if self.k_mer == 1:
+            return list("ACGT")
+        if not hasattr(self, "_kmer_index"):
+            self._kmer_index = ["".join(t) for t in product("ACGT", repeat=self.k_mer)]
+        return self._kmer_index
 
     def get_table(self, normed=False, pseudocount=1):
         """
@@ -541,6 +543,3 @@ class BaseCounter(object):
             return stats / stats.sum()
         else:
             return stats
-
-    def _init_table(self):
-        return ["".join(comb) for comb in list(product(*(self.k_mer * ["ACGT"])))]

--- a/codonbias/utils.py
+++ b/codonbias/utils.py
@@ -149,6 +149,30 @@ def mean(weights, counts):
     return (weights[nn] * counts.reindex(nn)).sum() / counts.reindex(nn).sum()
 
 
+def mean_array(weights, counts):
+    """
+    Count-weighted arithmetic mean over aligned ndarray inputs.
+
+    Fast-path sibling of `mean` for the count_array hot path. Both arrays
+    must be aligned to the same codon (or k-mer) order; non-finite
+    entries in `weights` are masked out before the reduction.
+
+    Parameters
+    ----------
+    weights : numpy.ndarray
+        Codon scores, aligned to a fixed codon order.
+    counts : numpy.ndarray
+        Codon counts, aligned to the same order as `weights`.
+
+    Returns
+    -------
+    float
+        Arithmetic mean.
+    """
+    mask = np.isfinite(weights)
+    return (weights[mask] * counts[mask]).sum() / counts[mask].sum()
+
+
 def fetch_GCN_from_GtRNAdb(url=None, genome=None, domain=None):
     """
     Download a tRNA gene copy number (GCN) table for an organism

--- a/tests/stats/test_base_count_array.py
+++ b/tests/stats/test_base_count_array.py
@@ -1,8 +1,10 @@
 """Equivalence tests for BaseCounter.count_array.
 
-Compares the vectorised k_mer=1 implementation against an inline reference
-that reproduces the pre-vectorisation Python loop. The k_mer>1 path uses
-Counter directly via the existing `count()` API and is covered separately.
+Compares the vectorised implementation against an inline reference that
+reproduces the pre-vectorisation Python Counter loop. Covers k_mer in
+[1, 3] across the frame/step axes — the k_mer>1 path keeps the original
+``range(frame-1, last_pos, step)`` semantics (start positions are
+strided; bases inside each k-mer are always consecutive).
 
 Mirrors the structure of tests/stats/test_count_array.py.
 """
@@ -22,7 +24,7 @@ def _reference_count_array(counter, seq):
         raise ValueError(f"sequence is not a string: {type(seq)}")
     seq = seq.upper().replace("U", "T")
     last_pos = len(seq) - counter.k_mer + 1
-    return pd.Series(
+    raw = pd.Series(
         Counter(
             [
                 seq[i : i + counter.k_mer]
@@ -31,11 +33,16 @@ def _reference_count_array(counter, seq):
         ),
         dtype=int,
     )
+    if raw.empty:
+        return raw
+    # Drop k-mers containing any non-ACGT base (matches count_array).
+    valid = raw.index.to_series().str.fullmatch(r"[ACGT]+")
+    return raw[valid]
 
 
 def _canonical(counter, out):
     """Normalise a count output to a full-alphabet int Series for comparison."""
-    idx = counter._init_table()
+    idx = counter.kmer_index
     if isinstance(out, np.ndarray):
         return pd.Series(out, index=idx).astype(int)
     return out.reindex(idx).fillna(0).astype(int)
@@ -60,8 +67,9 @@ SEQS = {
 @pytest.mark.parametrize("name,seq", list(SEQS.items()))
 @pytest.mark.parametrize("step", [1, 3])
 @pytest.mark.parametrize("frame", [1, 2, 3])
-def test_count_array_kmer1_equivalence(name, seq, step, frame):
-    counter = BaseCounter(k_mer=1, step=step, frame=frame)
+@pytest.mark.parametrize("k_mer", [1, 2, 3])
+def test_count_array_equivalence(name, seq, step, frame, k_mer):
+    counter = BaseCounter(k_mer=k_mer, step=step, frame=frame)
     new = _canonical(counter, counter.count_array(seq))
     ref = _canonical(counter, _reference_count_array(counter, seq))
     pd.testing.assert_series_equal(new, ref, check_names=False)
@@ -73,35 +81,20 @@ def test_count_array_rejects_non_string():
         counter.count_array(12345)
 
 
-def test_count_array_rejects_non_kmer_1():
-    counter = BaseCounter(k_mer=2)
-    with pytest.raises(NotImplementedError, match="k_mer=1"):
-        counter.count_array("ACGTACGT")
-
-
-def test_count_array_does_not_mutate_state():
+@pytest.mark.parametrize("k_mer", [1, 2, 3])
+def test_count_array_does_not_mutate_state(k_mer):
     """count_array is stateless; self.counts must remain unset."""
-    counter = BaseCounter()
-    counter.count_array("ACGTACGT")
+    counter = BaseCounter(k_mer=k_mer)
+    counter.count_array("ACGTACGT" * 2)
     assert not hasattr(counter, "counts")
 
 
-def test_count_array_return_shape_and_dtype():
-    """Contract: ndarray of shape (4,) in ACGT order."""
-    out = BaseCounter().count_array("ACGTACGT")
+@pytest.mark.parametrize("k_mer", [1, 2, 3])
+def test_count_array_return_shape_and_dtype(k_mer):
+    """Contract: ndarray of shape (4 ** k_mer,) in lex-product order."""
+    out = BaseCounter(k_mer=k_mer).count_array("ACGTACGT" * 2)
     assert isinstance(out, np.ndarray)
-    assert out.shape == (4,)
-
-
-def test_count_kmer2_fallback_unchanged():
-    """k_mer>1 still uses the Counter fallback — spot-check end-to-end."""
-    seq = "ACGTACGTACGT"
-    for step, frame in [(1, 1), (2, 1), (1, 2)]:
-        counter = BaseCounter(k_mer=2, step=step, frame=frame)
-        got = counter.count(seq).counts.astype(int)
-        ref_raw = _reference_count_array(counter, seq)
-        expected = ref_raw.reindex(counter._init_table()).fillna(0).astype(int)
-        pd.testing.assert_series_equal(got, expected, check_names=False)
+    assert out.shape == (4**k_mer,)
 
 
 def test_count_end_to_end_gc3_example():
@@ -119,7 +112,7 @@ def test_count_multi_seq_sum():
     # Sum across all sequences: A=4 (ATGAAA), C=3 (CCCGGG), G=4 (1+3), T=1.
     expected = (
         pd.Series({"A": 4, "C": 3, "G": 4, "T": 1}, dtype=float)
-        .reindex(counter._init_table())
+        .reindex(counter.kmer_index)
         .fillna(0)
     )
     pd.testing.assert_series_equal(got.astype(float), expected, check_names=False)

--- a/tests/stats/test_count_array.py
+++ b/tests/stats/test_count_array.py
@@ -3,7 +3,8 @@
 Compares the vectorised implementation against an inline reference that
 reproduces the pre-vectorisation Python loop. Covers edge cases around
 case, U→T, ambiguous bases, non-ACGT characters mid-sequence, short
-sequences, STOP handling, and non-default genetic codes.
+sequences, STOP handling, and non-default genetic codes. Generalised
+to k_mer in [1, 3] once the dense bincount path was extended.
 """
 
 import numpy as np
@@ -13,16 +14,28 @@ from codonbias.stats import CodonCounter
 
 
 def _reference_count_array(counter, seq):
-    """Pre-vectorisation implementation, inlined here as the reference."""
+    """Reference: codon-id sliding window over the python-level codon list.
+
+    Lex-product order mirrors ``count_array``: a k-mer with codon indices
+    ``(i0, i1, ...)`` lands at ``sum(i_j * n_codons ** (k-1-j))``.
+    """
     if not isinstance(seq, str):
         raise ValueError(f"sequence is not a string: {type(seq)}")
     seq = seq.upper().replace("U", "T")
     codon_to_idx = {c: i for i, c in enumerate(counter.codon_index)}
-    counts = np.zeros(len(codon_to_idx), dtype=float)
-    for i in range(0, len(seq) - 2, 3):
-        idx = codon_to_idx.get(seq[i : i + 3])
-        if idx is not None:
-            counts[idx] += 1
+    n_codons = len(codon_to_idx)
+    k = counter.k_mer
+    n_out = n_codons**k
+    counts = np.zeros(n_out, dtype=float)
+    span = 3 * k
+    for i in range(0, len(seq) - span + 1, 3):
+        idxs = [codon_to_idx.get(seq[i + 3 * j : i + 3 * (j + 1)]) for j in range(k)]
+        if any(idx is None for idx in idxs):
+            continue
+        bucket = 0
+        for j, idx in enumerate(idxs):
+            bucket += idx * n_codons ** (k - 1 - j)
+        counts[bucket] += 1
     return counts
 
 
@@ -49,22 +62,24 @@ SEQS = {
 
 @pytest.mark.parametrize("name,seq", list(SEQS.items()))
 @pytest.mark.parametrize("ignore_stop", [True, False])
-def test_count_array_equivalence_genetic_code_1(name, seq, ignore_stop):
-    counter = CodonCounter(ignore_stop=ignore_stop)
+@pytest.mark.parametrize("k_mer", [1, 2, 3])
+def test_count_array_equivalence_genetic_code_1(name, seq, ignore_stop, k_mer):
+    counter = CodonCounter(ignore_stop=ignore_stop, k_mer=k_mer)
 
     new_counts = counter.count_array(seq)
     ref_counts = _reference_count_array(counter, seq)
 
     np.testing.assert_array_equal(
-        new_counts, ref_counts, err_msg=f"counts mismatch on {name}"
+        new_counts, ref_counts, err_msg=f"counts mismatch on {name} (k_mer={k_mer})"
     )
 
 
 @pytest.mark.parametrize("genetic_code", [2, 11])
-def test_count_array_equivalence_other_genetic_codes(genetic_code):
+@pytest.mark.parametrize("k_mer", [1, 2])
+def test_count_array_equivalence_other_genetic_codes(genetic_code, k_mer):
     """Non-standard genetic codes have different STOP sets — confirm the
     LUT population respects the code-specific codon_index."""
-    counter = CodonCounter(genetic_code=genetic_code, ignore_stop=True)
+    counter = CodonCounter(genetic_code=genetic_code, ignore_stop=True, k_mer=k_mer)
     seq = "ATGAAACCCGGGTTTTGATAATAGCTG"  # includes TGA / TAA / TAG
     new_counts = counter.count_array(seq)
     ref_counts = _reference_count_array(counter, seq)
@@ -77,23 +92,25 @@ def test_count_array_rejects_non_string():
         counter.count_array(12345)
 
 
-def test_count_array_rejects_non_kmer_1():
-    counter = CodonCounter(k_mer=2)
-    with pytest.raises(NotImplementedError, match="k_mer=1"):
-        counter.count_array("ATGAAA")
+def test_count_array_rejects_kmer_above_3():
+    counter = CodonCounter(k_mer=4)
+    with pytest.raises(NotImplementedError, match="k_mer <= 3"):
+        counter.count_array("ATGAAA" * 4)
 
 
-def test_count_array_does_not_mutate_state():
+@pytest.mark.parametrize("k_mer", [1, 2, 3])
+def test_count_array_does_not_mutate_state(k_mer):
     """count_array is stateless; self.counts must remain unset."""
-    counter = CodonCounter()
-    counter.count_array("ATGAAACCCGGG")
+    counter = CodonCounter(k_mer=k_mer)
+    counter.count_array("ATGAAACCCGGGTTTTAA" * 2)
     assert not hasattr(counter, "counts")
 
 
-def test_count_array_return_shape_and_dtype():
-    """Contract: float ndarray of shape (len(codon_index),)."""
-    counter = CodonCounter()  # default: genetic_code=1, ignore_stop=True
-    counts = counter.count_array("ATGAAACCCGGG")
+@pytest.mark.parametrize("k_mer", [1, 2, 3])
+def test_count_array_return_shape_and_dtype(k_mer):
+    """Contract: float ndarray of shape (len(codon_index) ** k_mer,)."""
+    counter = CodonCounter(k_mer=k_mer)  # default: genetic_code=1, ignore_stop=True
+    counts = counter.count_array("ATGAAACCCGGG" * k_mer)
     assert isinstance(counts, np.ndarray)
     assert counts.dtype.kind == "f"
-    assert counts.shape == (len(counter.codon_index),)
+    assert counts.shape == (len(counter.codon_index) ** k_mer,)


### PR DESCRIPTION
## Summary

Generalises ``count_array`` from k_mer=1 to k_mer in [1, 3] for ``CodonCounter`` and to any k_mer for ``BaseCounter``, then makes ``count(seqs)`` a thin pandas formatter on top of it. CAI and CodonPairBias drop the pandas-Series detour on the k_mer>1 hot path and call ``count_array`` + ``geomean_array`` / ``mean_array`` directly.

This finishes the deepening loop opened in the module-depth review: ``count_array`` is now the single vectorised entry point, ``count(seqs)`` is purely formatting on top, and scores call into either depending on whether they need the formatted shape.

The Python ``Counter`` fallback is retired. ``CodonCounter`` raises ``NotImplementedError`` for k_mer >= 4 (a dense aligned vector would exceed 14M entries; no in-package usage).

### Perf

Measured on a 3.6 kb sequence:
- **CAI k_mer=2**: 0.82 ms/call (Counter+pandas) -> 0.05 ms/call (count_array+geomean_array). ~16x.
- **CodonCounter.count_array k_mer=2**: 0.04 ms/call. count(seq).counts (ndarray + Series wrap) is 0.11 ms/call -- the wrap is over half the cost, which is why CAI/CPB rewiring matters.
- **k_mer=1** paths unchanged within noise (0.030 ms vs 0.031 ms; one extra branch check).

### Commit Plan

1. ``refactor: rename _codon_lex_to_aa to _codon_lex_to_idx`` -- the LUT stored codon indices, not aa indices; renaming clears the way for the generalisation to read cleanly.
2. ``perf: vectorise CodonCounter.count_array for k_mer in [1, 3]`` -- generalises the LUT/bincount pipeline; sliding window over codon ids; raises for k_mer >= 4.
3. ``refactor: route CodonCounter.count through count_array`` -- drops ``_count_kmer_n`` / ``_format_counts``; ``count()`` becomes a pandas formatter on top of ``count_array``; introduces lazy ``_kmer_index`` cache.
4. ``perf: CAI and CodonPairBias call count_array directly for any k_mer`` -- precomputes ``_log_weights_arr`` / ``_weights_arr`` aligned to the lex product; adds ``mean_array`` (sibling of ``geomean_array``) and ``CodonCounter.kmer_index`` (public property for callers needing the lex order).
5. ``perf: vectorise BaseCounter.count_array for any k_mer`` -- same pattern; sliding window respects ``frame`` / ``step`` semantics; ``BaseCounter._count_kmer_n`` and ``_init_table`` retired in favour of ``kmer_index``.

## Test plan

- [x] ``pytest tests/`` -- 440 passed (was 294; growth is from ``k_mer in [1, 2, 3]`` parametrisation on count_array equivalence tests).
- [x] CAI k_mer=2 regression CSV unchanged (the integration safety net for commits 2-4).
- [x] ``ruff format codonbias/ tests/`` -- clean.
- [x] ``ruff check codonbias/ tests/`` -- clean.