### PR TITLE
refactor: unify ENC k_mer=1/k_mer>1 paths around count_array

### DIFF
--- a/codonbias/scores.py
+++ b/codonbias/scores.py
@@ -551,182 +551,115 @@ class EffectiveNumberOfCodons(ScalarScore, WeightScore):
             k_mer=k_mer, concat_index=True, genetic_code=genetic_code, ignore_stop=True
         )  # score is not defined for STOP codons
 
-        self.template = self.counter.count("").get_aa_table().to_frame()
-        self.aa_deg = self.template.groupby("aa").size()
-
-        if self.k_mer == 1:
-            self._aa_deg = np.bincount(
-                self.counter.aa_group, minlength=self.counter.n_aa
-            )
-            self._bcc_uniform = 1.0 / self._aa_deg[self.counter.aa_group]
-            # Reused on every bg_correction=True sequence to skip the
-            # pd.Series wrapping of BaseCounter.count()/get_table().
-            self._base_counter = BaseCounter()
+        # Per-(k-mer aa-tuple) degeneracy: how many k-mer codons map to
+        # each aa-tuple group. For k_mer=1 this is the textbook aa
+        # degeneracy; for k_mer>1 it's the cartesian product (e.g.,
+        # Met-Ile -> 1*3 = 3).
+        aa_group_kmer = self.counter.aa_group_kmer
+        n_aa_kmer = self.counter.n_aa**self.k_mer
+        self._aa_deg = np.bincount(aa_group_kmer, minlength=n_aa_kmer)
+        self._bcc_uniform = 1.0 / self._aa_deg[aa_group_kmer]
+        # Shared BaseCounter for bg_correction=True; sized to k_mer=1 since
+        # _calc_BNC works on individual nucleotides regardless of k_mer.
+        self._base_counter = BaseCounter()
 
         self.BCC_unif = self._calc_BCC(self._calc_BNC(""))
 
     def _calc_seq_weights(self, seq, background=None):
-        if self.k_mer == 1:
-            return 1 / self._calc_F(seq, background=background)[0]
-        else:
-            return 1 / self._calc_F(seq, background=background)[0]["F"]
+        return 1 / self._calc_F(seq, background=background)[0]
 
     def _calc_score(self, seq, background=None):
-        if self.k_mer == 1:
-            return self._calc_score_single_kmer(seq, background)
-
         F, P, N = self._calc_F(seq, background=background)
-        F["deg"] = self.aa_deg
-        F["N"] = N
-        deg_count = F.groupby("deg").size().to_frame("deg_count")
 
-        F = F.loc[(N > 1) & (F["F"] > 1e-6) & np.isfinite(F["F"])]
-        if self.mean == "unweighted":
-            F = F.groupby("deg", group_keys=False).mean().join(deg_count, how="right")
-        elif self.mean == "weighted":
-            F["F"] = F["F"] * F["N"]
-            F = F.groupby("deg")["F"].sum() / F.groupby("deg")["N"].sum()
-            F = F.to_frame("F").join(deg_count, how="right")
-        else:
-            raise ValueError(f'unknown mean="{self.mean}"')
-
-        miss_3 = np.isnan(F.loc[3, "F"])
-        F["F"] = F["F"].fillna(1 / F.index.to_series())  # use 1/deg
-        if miss_3:
-            F.loc[3, "F"] = 0.5 * (F.loc[2, "F"] + F.loc[4, "F"])
-
-        ENC = (F["deg_count"] / F["F"]).sum()
-        return min([len(P), ENC]) ** (1 / self.k_mer)
-
-    def _calc_score_single_kmer(self, seq, background=None):
-        F, P, N = self._calc_F_single_kmer(seq, background)
-        F_by_deg = {}
+        # Aggregate F by aa-tuple degeneracy. For k_mer=1 this is the
+        # textbook ENC by-degeneracy mean (Wright/Sun-Yang-Xia); for
+        # k_mer>1 it is the Alexaki-style codon-pair generalisation.
         unique_degs, deg_counts = np.unique(self._aa_deg, return_counts=True)
-
-        for deg in unique_degs:
-            mask = self._aa_deg == deg
-            valid = mask & (N > 1) & (F > 1e-6) & np.isfinite(F)
+        F_by_deg = np.full(len(unique_degs), np.nan)
+        for i, deg in enumerate(unique_degs):
+            in_group = self._aa_deg == deg
+            valid = in_group & (N > 1) & (F > 1e-6) & np.isfinite(F)
+            if not valid.any():
+                continue
             if self.mean == "unweighted":
-                F_by_deg[deg] = F[valid].mean() if valid.any() else np.nan
+                F_by_deg[i] = F[valid].mean()
             elif self.mean == "weighted":
                 sum_N = N[valid].sum()
-                F_by_deg[deg] = (
-                    (F[valid] * N[valid]).sum() / sum_N if sum_N > 0 else np.nan
-                )
+                if sum_N > 0:
+                    F_by_deg[i] = (F[valid] * N[valid]).sum() / sum_N
             else:
                 raise ValueError(f'unknown mean="{self.mean}"')
 
-        miss_3 = np.isnan(F_by_deg.get(3, np.nan))
-        for deg in unique_degs:
-            if np.isnan(F_by_deg[deg]):
-                F_by_deg[deg] = 1.0 / deg
+        # Wright/Alexaki imputation: missing aa-degeneracies fall back to
+        # 1/deg, with deg=3 specifically interpolated between 2 and 4 if
+        # absent (Wright 1990, applied uniformly across k_mer).
+        is_3 = unique_degs == 3
+        miss_3 = is_3.any() and np.isnan(F_by_deg[is_3]).any()
+        nan_mask = np.isnan(F_by_deg)
+        F_by_deg[nan_mask] = 1.0 / unique_degs[nan_mask]
         if miss_3:
-            F_by_deg[3] = 0.5 * (F_by_deg.get(2, 0.5) + F_by_deg.get(4, 0.25))
+            f2 = F_by_deg[unique_degs == 2]
+            f4 = F_by_deg[unique_degs == 4]
+            if len(f2) and len(f4):
+                F_by_deg[is_3] = 0.5 * (f2 + f4)
 
-        ENC = sum(count / F_by_deg[deg] for deg, count in zip(unique_degs, deg_counts))
-        return min(len(P), ENC)
+        ENC = (deg_counts / F_by_deg).sum()
+        return min(len(P), ENC) ** (1.0 / self.k_mer)
 
     def _calc_F(self, seq, background=None):
-        if self.k_mer == 1:
-            return self._calc_F_single_kmer(seq, background)
+        """Per-(aa-tuple) F-values, P (per-k-mer relative freq), N (per-aa-tuple totals).
 
-        counts = self.counter.count(seq).get_aa_table()
-        counts += self.pseudocount  # Sun, Yang & Xia 2013
-        N = counts.groupby("aa").sum()
-        P = counts / N
-
-        if background is None:
-            background = seq
-        if self.bg_correction:
-            BCC = self._calc_BCC(self._calc_BNC(background))
-        else:
-            BCC = self.BCC_unif
-
-        if not self.robust:
-            chi2 = N * ((P - BCC) ** 2 / BCC).groupby("aa").sum()  # Novembre 2002
-            F = ((chi2 + N - self.aa_deg) / (N - 1) / self.aa_deg).to_frame("F")
-        else:
-            chi2 = ((P - BCC) ** 2 / BCC).groupby("aa").sum()  # modified Novembre 2002
-            F = ((chi2 + 1) / self.aa_deg).to_frame("F")
-            # converges to Sun, Yang & Xia for BCC_unif, i.e., sum(p**2)
-        return F, P, N
-
-    def _calc_F_single_kmer(self, seq, background=None):
+        F: shape (n_aa**k_mer,) -- codon-tuple homozygosity per aa-tuple.
+        P: shape (n_codons**k_mer,) -- relative freq of each k-mer w.r.t. its aa-tuple.
+        N: shape (n_aa**k_mer,) -- total counts per aa-tuple.
         """
-        Returns a tuple of 3 np.arrays
-        F: 1D array of shape (n_aa,) representing codon homozygosity
-        P: 1D array of shape (n_codons,) representing relative frequency of each codon w.r.t its group
-        N: 1D array of shape (n_aa,) containing the total absolute counts of each AA observed in the sequence
-        """
-        counts = self.counter.count_array(seq) + self.pseudocount
-        aa_group = self.counter.aa_group
+        counts = (
+            self.counter.count_array(seq) + self.pseudocount
+        )  # Sun, Yang & Xia 2013
+        aa_group = self.counter.aa_group_kmer
+        n_aa_kmer = self._aa_deg.size
 
-        N = np.bincount(aa_group, weights=counts, minlength=self.counter.n_aa)
-
-        # Safely divide, leaving NaN where N is 0
+        N = np.bincount(aa_group, weights=counts, minlength=n_aa_kmer)
         with np.errstate(divide="ignore", invalid="ignore"):
             P = counts / N[aa_group]
 
         if background is None:
             background = seq
         BCC = (
-            self._calc_BCC(self._calc_BNC(background)).values
+            self._calc_BCC(self._calc_BNC(background))
             if self.bg_correction
             else self._bcc_uniform
         )
 
-        # Safely compute chi2
         with np.errstate(divide="ignore", invalid="ignore"):
             chi2 = (P - BCC) ** 2 / BCC
+        # Mimic pandas' NaN-skipping sum: drop NaN entries before bincount.
+        valid = ~np.isnan(chi2)
+        chi2_aa = np.bincount(aa_group[valid], weights=chi2[valid], minlength=n_aa_kmer)
 
-        # Pandas .sum() ignores NaNs by default. We mimic this by masking NaNs before bincount.
-        valid_chi2 = ~np.isnan(chi2)
-        chi2_aa = np.bincount(
-            aa_group[valid_chi2], weights=chi2[valid_chi2], minlength=self.counter.n_aa
-        )
-
-        if not self.robust:
-            with np.errstate(divide="ignore", invalid="ignore"):
-                F = (N * chi2_aa + N - self._aa_deg) / (N - 1) / self._aa_deg
+        if self.robust:
+            F = (chi2_aa + 1) / self._aa_deg  # Sun, Yang & Xia 2013 (modified Novembre)
         else:
-            F = (chi2_aa + 1) / self._aa_deg
-
+            with np.errstate(divide="ignore", invalid="ignore"):
+                F = (
+                    (N * chi2_aa + N - self._aa_deg) / (N - 1) / self._aa_deg
+                )  # Novembre 2002
         return F, P, N
 
     def _calc_BNC(self, seq):
-        """Compute the background NUCLEOTIDE composition of the sequence.
-
-        k_mer=1 returns an ndarray in ACGT order; k_mer>1 returns a
-        pd.Series (legacy fallback used by the k_mer>1 _calc_BCC path).
-        """
-        if self.k_mer == 1:
-            counts = self._base_counter.count_array(seq).astype(float) + 1
-            counts /= counts.sum()
-            return counts
-        return BaseCounter(seq).get_table(normed=True)
+        """Background nucleotide composition: shape (4,), ACGT order, normalised."""
+        counts = self._base_counter.count_array(seq).astype(float) + 1
+        return counts / counts.sum()
 
     def _calc_BCC(self, BNC):
-        """Compute the background CODON composition of the sequence."""
-        if self.k_mer == 1:
-            # BNC is an ndarray in ACGT order from _calc_BNC's k_mer=1 path.
-            bcc = BNC[self.counter.codon_base_idx].prod(axis=1)
-            aa_sums = np.bincount(
-                self.counter.aa_group,
-                weights=bcc,
-                minlength=self.counter.n_aa,
-            )
-            bcc = bcc / aa_sums[self.counter.aa_group]
-            return pd.Series(bcc, index=self.template.index, name="bcc")
-
-        BCC = self.template.copy()
-        BCC["bcc"] = [
-            np.prod([BNC[c] for c in cod])
-            for cod in BCC.index.get_level_values("codon")
-        ]
-        BCC = BCC["bcc"]
-        BCC /= BCC.groupby("aa").sum()
-
-        return BCC
+        """Background k-mer composition: independent product of base probs,
+        renormalised within each aa-tuple group. Shape (n_codons**k_mer,).
+        """
+        bcc = BNC[self.counter.codon_base_idx_kmer].prod(axis=1)
+        aa_sums = np.bincount(
+            self.counter.aa_group_kmer, weights=bcc, minlength=self._aa_deg.size
+        )
+        return bcc / aa_sums[self.counter.aa_group_kmer]
 
 
 class TrnaAdaptationIndex(ScalarScore, VectorScore):

--- a/codonbias/stats.py
+++ b/codonbias/stats.py
@@ -95,14 +95,13 @@ class CodonCounter(object):
 
         # Per-codon base indices (A=0 C=1 G=2 T=3) for callers that need
         # to read background nucleotide compositions. Shape
-        # (len(codon_index), 3) int8. Defined only for k_mer=1; k_mer>1
-        # callers don't currently need this LUT.
-        if self.k_mer == 1:
-            base_to_idx = {"A": 0, "C": 1, "G": 2, "T": 3}
-            self.codon_base_idx = np.array(
-                [[base_to_idx[b] for b in cod] for cod in self.codon_index],
-                dtype=np.int8,
-            )
+        # (len(codon_index), 3) int8. Always built; k_mer>1 callers
+        # consume it via ``codon_base_idx_kmer`` below.
+        base_to_idx = {"A": 0, "C": 1, "G": 2, "T": 3}
+        self.codon_base_idx = np.array(
+            [[base_to_idx[b] for b in cod] for cod in self.codon_index],
+            dtype=np.int8,
+        )
 
     def count_array(self, seq):
         """Stateless k-mer codon count.
@@ -224,6 +223,50 @@ class CodonCounter(object):
                 "".join(t) for t in product(self.codon_index, repeat=self.k_mer)
             ]
         return self._kmer_index
+
+    @property
+    def aa_group_kmer(self):
+        """Aa-tuple group id for each k-mer in lex-product order.
+
+        Shape ``(len(codon_index) ** k_mer,)``. For k_mer=1 this is just
+        ``aa_group``. For k_mer>1 the i-th codon position contributes
+        ``aa_group[c_i] * n_aa ** (k - 1 - i)``, so the result indexes
+        the cartesian product of aa groups across positions. Lets
+        aa-grouped reductions (e.g., ENC's chi-square sum) work
+        uniformly across k_mer via ``np.bincount(aa_group_kmer, ...)``.
+        Built lazily.
+        """
+        if self.k_mer == 1:
+            return self.aa_group
+        if not hasattr(self, "_aa_group_kmer"):
+            n_codons = len(self.codon_index)
+            # idx[i] is shape (n_codons**k_mer,) and gives the codon index
+            # at k-mer position i for every bucket in lex-product order.
+            idx = np.indices((n_codons,) * self.k_mer).reshape(self.k_mer, -1)
+            result = np.zeros(n_codons**self.k_mer, dtype=np.int32)
+            for i in range(self.k_mer):
+                result += self.aa_group[idx[i]] * self.n_aa ** (self.k_mer - 1 - i)
+            self._aa_group_kmer = result
+        return self._aa_group_kmer
+
+    @property
+    def codon_base_idx_kmer(self):
+        """Per-k-mer base indices, shape ``(n_codons ** k_mer, 3 * k_mer)``.
+
+        Generalises ``codon_base_idx`` to any k_mer: for each k-mer in
+        lex-product order, the row holds the base indices at all
+        ``3 * k_mer`` positions (concatenated across k-mer positions).
+        Built lazily.
+        """
+        if self.k_mer == 1:
+            return self.codon_base_idx
+        if not hasattr(self, "_codon_base_idx_kmer"):
+            n_codons = len(self.codon_index)
+            idx = np.indices((n_codons,) * self.k_mer).reshape(self.k_mer, -1)
+            self._codon_base_idx_kmer = np.concatenate(
+                [self.codon_base_idx[idx[i]] for i in range(self.k_mer)], axis=1
+            )
+        return self._codon_base_idx_kmer
 
     def get_codon_table(self, normed=False, pseudocount=1, nonzero=False):
         """

--- a/tests/scores/test_enc_calc_bcc.py
+++ b/tests/scores/test_enc_calc_bcc.py
@@ -1,82 +1,84 @@
-"""Equivalence test for EffectiveNumberOfCodons._calc_BCC vectorisation.
+"""Equivalence test for EffectiveNumberOfCodons._calc_BCC.
 
-The vectorised k_mer=1 path must match the pre-vectorisation listcomp
-implementation for arbitrary BNC distributions. After #18 the k_mer=1
-path takes an ndarray in ACGT order; the reference still uses a Series
-for its Series-indexed listcomp.
+The vectorised path must match a python-level reference for arbitrary
+BNC distributions. ``_calc_BCC`` returns an ndarray in ``kmer_index``
+order, normalised within each aa-tuple group; covered for k_mer in
+[1, 2].
 """
 
 import numpy as np
-import pandas as pd
 import pytest
 
 from codonbias.scores import EffectiveNumberOfCodons
 
 
-def _reference_calc_bcc(enc, BNC_series):
-    """Pre-vectorisation implementation (Series-indexed), inlined as reference."""
-    BCC = enc.template.copy()
-    BCC["bcc"] = [
-        np.prod([BNC_series[c] for c in cod])
-        for cod in BCC.index.get_level_values("codon")
-    ]
-    BCC = BCC["bcc"]
-    BCC /= BCC.groupby("aa").sum()
-    return BCC
+def _reference_calc_bcc(enc, BNC):
+    """Python-level reference: per-k-mer base-product, aa-group renormalisation."""
+    base_to_idx = {"A": 0, "C": 1, "G": 2, "T": 3}
+    kmer_index = enc.counter.kmer_index
+    aa_group = enc.counter.aa_group_kmer
+    n_aa_kmer = enc._aa_deg.size
+
+    bcc = np.array(
+        [np.prod([BNC[base_to_idx[b]] for b in kmer]) for kmer in kmer_index],
+        dtype=float,
+    )
+    aa_sums = np.bincount(aa_group, weights=bcc, minlength=n_aa_kmer)
+    return bcc / aa_sums[aa_group]
 
 
-def _probs_to_pair(probs):
-    """Return (ndarray, Series) forms of the same BNC distribution."""
-    return np.asarray(probs, dtype=float), pd.Series(probs, index=list("ACGT"))
-
-
+@pytest.mark.parametrize("k_mer", [1, 2])
 @pytest.mark.parametrize("seed", [0, 1, 42, 2026])
-def test_calc_bcc_equivalence_random_bnc(seed):
-    enc = EffectiveNumberOfCodons(bg_correction=True)
+def test_calc_bcc_equivalence_random_bnc(seed, k_mer):
+    enc = EffectiveNumberOfCodons(k_mer=k_mer, bg_correction=True)
     rng = np.random.default_rng(seed)
-    BNC_arr, BNC_ser = _probs_to_pair(rng.dirichlet([1, 1, 1, 1]))
+    BNC = rng.dirichlet([1, 1, 1, 1])
 
-    got = enc._calc_BCC(BNC_arr)
-    expected = _reference_calc_bcc(enc, BNC_ser)
+    got = enc._calc_BCC(BNC)
+    expected = _reference_calc_bcc(enc, BNC)
 
-    np.testing.assert_allclose(got.values, expected.values, rtol=1e-12)
-    assert got.index.equals(expected.index)
+    np.testing.assert_allclose(got, expected, rtol=1e-12)
 
 
-def test_calc_bcc_equivalence_uniform_bnc():
+@pytest.mark.parametrize("k_mer", [1, 2])
+def test_calc_bcc_equivalence_uniform_bnc(k_mer):
     """Uniform BNC (equivalent to the BCC_unif init path)."""
-    enc = EffectiveNumberOfCodons(bg_correction=True)
-    BNC_arr, BNC_ser = _probs_to_pair([0.25] * 4)
-    got = enc._calc_BCC(BNC_arr)
-    expected = _reference_calc_bcc(enc, BNC_ser)
-    np.testing.assert_allclose(got.values, expected.values, rtol=1e-12)
+    enc = EffectiveNumberOfCodons(k_mer=k_mer, bg_correction=True)
+    BNC = np.array([0.25] * 4)
+    got = enc._calc_BCC(BNC)
+    expected = _reference_calc_bcc(enc, BNC)
+    np.testing.assert_allclose(got, expected, rtol=1e-12)
 
 
-def test_calc_bcc_equivalence_skewed_bnc():
+@pytest.mark.parametrize("k_mer", [1, 2])
+def test_calc_bcc_equivalence_skewed_bnc(k_mer):
     """Extreme skew: one base dominates, another ~0."""
-    enc = EffectiveNumberOfCodons(bg_correction=True)
-    BNC_arr, BNC_ser = _probs_to_pair([0.7, 0.28, 0.01, 0.01])
-    got = enc._calc_BCC(BNC_arr)
-    expected = _reference_calc_bcc(enc, BNC_ser)
-    np.testing.assert_allclose(got.values, expected.values, rtol=1e-12)
+    enc = EffectiveNumberOfCodons(k_mer=k_mer, bg_correction=True)
+    BNC = np.array([0.7, 0.28, 0.01, 0.01])
+    got = enc._calc_BCC(BNC)
+    expected = _reference_calc_bcc(enc, BNC)
+    np.testing.assert_allclose(got, expected, rtol=1e-12)
 
 
-def test_calc_bcc_sums_to_one_per_aa():
-    """BCC is normalised within each amino acid group: each group sums to 1."""
-    enc = EffectiveNumberOfCodons(bg_correction=True)
+@pytest.mark.parametrize("k_mer", [1, 2])
+def test_calc_bcc_sums_to_one_per_aa(k_mer):
+    """BCC is normalised within each aa-tuple group: each group sums to 1."""
+    enc = EffectiveNumberOfCodons(k_mer=k_mer, bg_correction=True)
     rng = np.random.default_rng(0)
-    BNC_arr, _ = _probs_to_pair(rng.dirichlet([1, 1, 1, 1]))
-    bcc = enc._calc_BCC(BNC_arr)
-    aa_sums = bcc.groupby("aa").sum()
-    np.testing.assert_allclose(aa_sums.values, 1.0, rtol=1e-12)
+    BNC = rng.dirichlet([1, 1, 1, 1])
+    bcc = enc._calc_BCC(BNC)
+    aa_group = enc.counter.aa_group_kmer
+    aa_sums = np.bincount(aa_group, weights=bcc, minlength=enc._aa_deg.size)
+    # Drop empty groups (degenerate aa-tuples that don't occur).
+    np.testing.assert_allclose(aa_sums[enc._aa_deg > 0], 1.0, rtol=1e-12)
 
 
 @pytest.mark.parametrize("genetic_code", [2, 11])
 def test_calc_bcc_equivalence_other_genetic_codes(genetic_code):
-    """Non-standard genetic codes have different aa→codon groupings."""
+    """Non-standard genetic codes have different aa->codon groupings."""
     enc = EffectiveNumberOfCodons(bg_correction=True, genetic_code=genetic_code)
     rng = np.random.default_rng(genetic_code)
-    BNC_arr, BNC_ser = _probs_to_pair(rng.dirichlet([1, 1, 1, 1]))
-    got = enc._calc_BCC(BNC_arr)
-    expected = _reference_calc_bcc(enc, BNC_ser)
-    np.testing.assert_allclose(got.values, expected.values, rtol=1e-12)
+    BNC = rng.dirichlet([1, 1, 1, 1])
+    got = enc._calc_BCC(BNC)
+    expected = _reference_calc_bcc(enc, BNC)
+    np.testing.assert_allclose(got, expected, rtol=1e-12)

--- a/tests/stats/test_codon_base_idx.py
+++ b/tests/stats/test_codon_base_idx.py
@@ -1,7 +1,8 @@
-"""Contract tests for CodonCounter.codon_base_idx.
+"""Contract tests for CodonCounter.codon_base_idx (and its k-mer extension).
 
 The LUT is shared by ENC and RCB to compute per-codon background
-compositions. Lock in shape, dtype, ordering, and the k_mer=1 guard.
+compositions. Lock in shape, dtype, ordering. ``codon_base_idx_kmer``
+is the lazy k-mer extension consumed by ENC k_mer>1.
 """
 
 import numpy as np
@@ -33,8 +34,25 @@ def test_codon_base_idx_non_standard_genetic_codes(genetic_code):
     assert counter.codon_base_idx.shape == (len(counter.codon_index), 3)
 
 
-def test_codon_base_idx_undefined_for_kmer_gt_1():
-    """k_mer>1 paths don't currently need this LUT; attribute must be absent
-    so accidental reach-through fails loudly rather than silently."""
+@pytest.mark.parametrize("k_mer", [1, 2])
+def test_codon_base_idx_defined_for_any_kmer(k_mer):
+    """``codon_base_idx`` is per-codon and shape-stable across k_mer."""
+    counter = CodonCounter(k_mer=k_mer)
+    assert counter.codon_base_idx.shape == (len(counter.codon_index), 3)
+
+
+@pytest.mark.parametrize("k_mer", [1, 2])
+def test_codon_base_idx_kmer_shape(k_mer):
+    counter = CodonCounter(k_mer=k_mer)
+    n_codons = len(counter.codon_index)
+    assert counter.codon_base_idx_kmer.shape == (n_codons**k_mer, 3 * k_mer)
+
+
+def test_codon_base_idx_kmer_matches_kmer_index():
+    """Each row of the k-mer LUT must encode the bases of the corresponding
+    k-mer in ``kmer_index`` order."""
     counter = CodonCounter(k_mer=2)
-    assert not hasattr(counter, "codon_base_idx")
+    base_lut = {"A": 0, "C": 1, "G": 2, "T": 3}
+    lut = counter.codon_base_idx_kmer
+    for i, kmer in enumerate(counter.kmer_index):
+        assert tuple(lut[i].tolist()) == tuple(base_lut[b] for b in kmer)


### PR DESCRIPTION
## Summary

Closes the last open architecture-deepening candidate (candidate 8 in the module-depth review). ENC was the only score class still carrying two parallel implementations of the same statistic — k_mer=1 was vectorised through ``count_array`` while k_mer>1 sat on a pandas Series-based path with a python listcomp BCC build. This PR collapses them into a single body that runs the same operations for any k_mer.

The k_mer-awareness moves entirely into the counter's lex-product LUTs:

- ``CodonCounter.aa_group_kmer`` — lazy, shape ``(n_codons ** k_mer,)``, the cartesian aa-tuple group id for each lex-product k-mer.
- ``CodonCounter.codon_base_idx_kmer`` — lazy, shape ``(n_codons ** k_mer, 3 * k_mer)``, the base indices at every position of each k-mer.
- ``CodonCounter.codon_base_idx`` is now always built (was guarded behind ``if self.k_mer == 1``).

ENC then reads aligned ndarrays and runs the textbook chi-square / aggregation steps regardless of k_mer. The only ``k_mer`` references in the body are the pass-through to ``CodonCounter``, the ``n_aa_kmer = n_aa ** k_mer`` shape derivation, and the final-step k-th root from Alexaki's codon-pair generalisation. **No ``if self.k_mer == 1`` branches.**

### Numbers

- ENC class size: **257 → 188 lines** (-69)
- ENC k_mer=2, bg_correction=True: **22.9 ms → 0.21 ms** (~110x). The old python-listcomp BCC build over 3,721 codon-pairs was the bottleneck.
- ENC k_mer=1: 0.076 → 0.070 ms (within noise — same vectorised path as before).
- ENC E. coli regression CSVs (3 param combos × k_mer ∈ {1, 2}) match unchanged.

### Readability

The unified body trades one pandas-elegant line:

```python
chi2 = ((P - BCC) ** 2 / BCC).groupby("aa").sum()
```

for the 4-line ndarray dance:

```python
with np.errstate(divide="ignore", invalid="ignore"):
    chi2 = (P - BCC) ** 2 / BCC
valid = ~np.isnan(chi2)
chi2_aa = np.bincount(aa_group[valid], weights=chi2[valid], minlength=n_aa_kmer)
```

The same 4 lines were already in ``_calc_F_single_kmer`` for k_mer=1; unifying means we pay the cost once instead of twice. In return: single body, no dispatch, ENC reads as one statistic.

## Commit Plan

1. **``feat: aa_group_kmer and codon_base_idx_kmer LUTs on CodonCounter``** — adds the two new lazy properties and drops the k_mer=1 guard on ``codon_base_idx``. Updates the prior 'undefined for k_mer>1' contract test to assert presence and shape stability.
2. **``refactor: unify ENC k_mer=1/k_mer>1 paths around count_array``** — collapses the two ``_calc_*_single_kmer`` methods, ``_calc_BNC`` and ``_calc_BCC`` k_mer branches, into single bodies. Updates ``test_enc_calc_bcc.py`` to compare ndarrays against an ndarray-form python-loop reference, parametrised over k_mer ∈ [1, 2].

## Test plan

- [x] ``pytest tests/`` — 451 passed (was 440; growth from k_mer=2 parametrisations on the BCC equivalence test and the new k-mer LUT contract tests).
- [x] ENC E. coli regression CSVs unchanged (3 param combos × k_mer ∈ {1, 2}).
- [x] ``ruff format codonbias/ tests/`` — clean.
- [x] ``ruff check codonbias/ tests/`` — clean.